### PR TITLE
[fix] update:showSearchDropdown event가 계속 emit되는 이슈 해결

### DIFF
--- a/src/DataEntry/SearchInput.vue
+++ b/src/DataEntry/SearchInput.vue
@@ -93,7 +93,7 @@ export default {
 	},
 	methods: {
 		hideSearchDropdown() {
-			this.$emit('update:showSearchDropdown', false);
+			if (this.showSearchDropdown) this.$emit('update:showSearchDropdown', false);
 		},
 		handleTyping(e) {
 			this.isTyping = true;


### PR DESCRIPTION
hideSearchDown method가 v-click-outside directive에 걸려 있습니다. 해당 element가 가려져 있는 경우에도 외부 영역을 클릭 시 의도치 않게 event가 emit됩니다. 따라서 showSearchDropdown이 true일때만 해당 event가 emit하도록 수정하였습니다.