### PR TITLE
[fix] Toast width 오류 수정

### DIFF
--- a/src/Components/Message/Toast.vue
+++ b/src/Components/Message/Toast.vue
@@ -92,6 +92,8 @@ export default {
 	z-index: 9999;
 	@include border-radius(4px);
 	@include shadow4();
+	display: table; // width: fit-content 대체
+	max-width: 90%;
 
 	&--message {
 		margin: 0;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19399338/100063964-4181a980-2e75-11eb-838c-76e8d73bfb87.png)
- 오류: width가 고정된듯 텍스트가 두줄이 되는 현상
- 해결: width: fit-content는 IE에서 사용할 수 없어 display: table로 대체

참고
https://m.blog.naver.com/PostView.nhn?blogId=zimny327&logNo=221335293395&proxyReferer=https:%2F%2Fwww.google.com%2F
