### PR TITLE
Button 개선 (#169 원복), color gray -> secondary로 변경

### DIFF
--- a/assets/style/base/color.scss
+++ b/assets/style/base/color.scss
@@ -44,4 +44,4 @@ $yellow100: #FFFACC;
 $primary: $green600;
 $success: $blue600;
 $error: $red600;
-$gray: $gray600;
+$secondary: $gray600;

--- a/assets/style/base/utils.scss
+++ b/assets/style/base/utils.scss
@@ -178,11 +178,13 @@
 
 // position
 .p-absolute {
-  position: absolute;
+  position: absolute !important;
 }
-
+.p-fixed {
+  position: fixed !important;
+}
 .p-relative {
-  position: relative;
+  position: relative !important;
 }
 
 .flex {

--- a/src/Components/Button/Button.vue
+++ b/src/Components/Button/Button.vue
@@ -34,7 +34,7 @@
 import Icon from '@/src/Elements/Core/Icon/Icon';
 
 export const buttonSizes = ['small', 'medium', 'large', 'xlarge'];
-export const buttonColors = ['primary', 'success', 'gray', 'error'];
+export const buttonColors = ['primary', 'success', 'secondary', 'error'];
 export const buttonTypes = ['fill', 'outlined', 'text', 'icon'];
 
 export default {

--- a/src/Components/Button/Button.vue
+++ b/src/Components/Button/Button.vue
@@ -1,21 +1,30 @@
 <template>
 	<button
-		class="c-application c-button c-pointer"
-		:class="[computedSize, computedColor, computedFull, computedType, { loading: loading }]"
+		class="c-application c-button"
+		:class="[
+			computedSize,
+			computedColor,
+			computedFull,
+			computedType,
+			computedLoading,
+			computedFixed,
+			computedAbsolute,
+			computedShadow,
+		]"
 		v-bind="$attrs"
 		:disabled="disabled"
 		v-on="$listeners"
 	>
 		<template v-if="loading">
 			<div class="c-button--loading">
-				<Icon :name="computedIconName" :reversed="type === 'fill'" loading :spinner-color="color" />
+				<Icon :name="computedIconName" :reversed="isFillType" loading :spinner-color="color" />
 			</div>
 		</template>
-		<div class="c-button--icon" :style="$slots['left-icon'] && `margin-right: ${computedIconMargin}`">
+		<div class="c-button--icon" :class="setIconSpacing('left')">
 			<slot name="left-icon" />
 		</div>
 		<slot />
-		<div class="c-button--icon" :style="$slots['right-icon'] && `margin-left: ${computedIconMargin}`">
+		<div class="c-button--icon" :class="setIconSpacing('right')">
 			<slot name="right-icon" />
 		</div>
 	</button>
@@ -23,6 +32,11 @@
 
 <script>
 import Icon from '@/src/Elements/Core/Icon/Icon';
+
+export const buttonSizes = ['small', 'medium', 'large', 'xlarge'];
+export const buttonColors = ['primary', 'success', 'gray', 'error'];
+export const buttonTypes = ['fill', 'outlined', 'text', 'icon'];
+
 export default {
 	name: 'Button',
 	inheritAttrs: false,
@@ -31,35 +45,64 @@ export default {
 			type: String,
 			default: 'medium',
 			validator(value) {
-				return ['small', 'medium', 'large', 'xlarge'].indexOf(value) !== -1;
+				return buttonSizes.indexOf(value) !== -1;
 			},
 		},
 		color: {
 			type: String,
 			default: 'primary',
 			validator(value) {
-				return ['primary', 'success', 'gray', 'error'].indexOf(value) !== -1;
+				return buttonColors.indexOf(value) !== -1;
 			},
 		},
 		type: {
 			type: String,
 			default: 'fill',
 			validator(value) {
-				return ['fill', 'outlined', 'text'].indexOf(value) !== -1;
+				return buttonTypes.indexOf(value) !== -1;
 			},
 		},
 		full: {
 			type: Boolean,
 			default: false,
+			validator(value) {
+				return typeof value === 'boolean';
+			},
 		},
-		// disabled
 		disabled: {
 			type: Boolean,
 			default: false,
+			validator(value) {
+				return typeof value === 'boolean';
+			},
 		},
 		loading: {
 			type: Boolean,
 			default: false,
+			validator(value) {
+				return typeof value === 'boolean';
+			},
+		},
+		fixed: {
+			type: Boolean,
+			default: false,
+			validator(value) {
+				return typeof value === 'boolean';
+			},
+		},
+		absolute: {
+			type: Boolean,
+			default: false,
+			validator(value) {
+				return typeof value === 'boolean';
+			},
+		},
+		shadow: {
+			type: Boolean,
+			default: false,
+			validator(value) {
+				return typeof value === 'boolean';
+			},
 		},
 	},
 	computed: {
@@ -73,7 +116,19 @@ export default {
 			return this.type;
 		},
 		computedFull() {
-			return this.full ? 'full' : '';
+			return { full: this.full };
+		},
+		computedLoading() {
+			return { loading: this.loading };
+		},
+		computedShadow() {
+			return { shadow: this.shadow };
+		},
+		computedFixed() {
+			return { 'p-fixed': this.fixed };
+		},
+		computedAbsolute() {
+			return { 'p-absolute': this.absolute };
 		},
 		computedIconName() {
 			let size = this.size.charAt(0).toUpperCase() + this.size.slice(1);
@@ -82,17 +137,24 @@ export default {
 			return `IconSpinner${size}`;
 		},
 		computedIconMargin() {
-			const isMoreThanLarge = this.size.indexOf('large') !== -1;
-			return isMoreThanLarge ? '4px' : '2px';
+			const isXLarge = this.size.indexOf('xlarge') !== -1;
+			return isXLarge ? 4 : 2;
+		},
+		isFillType() {
+			return this.type === 'fill';
+		},
+	},
+	methods: {
+		setIconSpacing(position) {
+			const oppositePosition = position === 'left' ? 'r' : 'l';
+			return this.$slots[`${position}-icon`] && `m${oppositePosition}-${this.computedIconMargin}`;
 		},
 	},
 	components: { Icon },
 };
 </script>
 
-<style scoped lang="scss">
-/*@import '@/assets/style/base/main';*/
-
+<style lang="scss" scoped>
 .c-button {
 	color: $white;
 	background-color: $primary;
@@ -102,6 +164,8 @@ export default {
 	@include align-items(center);
 	@include justify-content(center);
 	position: relative;
+	cursor: pointer;
+
 	&:disabled {
 		cursor: not-allowed !important;
 		&:active {
@@ -168,6 +232,7 @@ export default {
 		width: 100%;
 	}
 	&.text {
+		@include f-normal();
 		background: transparent;
 		border: none;
 		color: $gray500;
@@ -366,7 +431,12 @@ export default {
 		}
 	}
 }
+
 .loading {
 	@include disabled();
+}
+
+.shadow {
+	@include shadow4();
 }
 </style>

--- a/src/Elements/Core/Colors/index.js
+++ b/src/Elements/Core/Colors/index.js
@@ -45,7 +45,7 @@ export const yellow100 = '#FFFACC';
 export const primary = green600;
 export const success = blue600;
 export const error = red600;
-export const gray = gray600;
+export const secondary = gray600;
 
 export const colors = {
     black: black,
@@ -82,7 +82,7 @@ export const colors = {
     primary: primary,
     success: success,
     error: error,
-    gray: gray,
+    secondary: secondary,
 };
 
 export const colorKeys = [...Object.keys(colors)];

--- a/src/Elements/Core/Icon/Icon.vue
+++ b/src/Elements/Core/Icon/Icon.vue
@@ -297,11 +297,11 @@ export default {
 				fill: 'white',
 			},
 			error: {
-				stroke: '#E8EAED',
+				stroke: '#FFDFDF',
 				fill: '#FA5252',
 			},
 			errorReversed: {
-				stroke: '#CC0000',
+				stroke: '#CC2727',
 				fill: 'white',
 			},
 		};

--- a/stories/Button/Button.stories.mdx
+++ b/stories/Button/Button.stories.mdx
@@ -1,5 +1,5 @@
 import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
-import Button from "@/src/Components/Button/Button";
+import Button, { buttonSizes, buttonColors, buttonTypes } from "@/src/Components/Button/Button";
 import Icon from "@/src/Elements/Core/Icon/Icon";
 
 <Meta
@@ -10,74 +10,45 @@ import Icon from "@/src/Elements/Core/Icon/Icon";
       description: "버튼에 들어갈 텍스트",
       defaultValue: "버튼",
       control: { type: "text" },
-      table: {
-        type: {
-          summary: null,
-        },
-      },
     },
     size: {
-      description: "버튼의 크기<br/>`String`",
-      table: {
-        type: {
-          summary: "목록",
-          detail: '"small" "medium" "large" "xlarge"',
-        },
-      },
+      description: "버튼의 크기",
       control: {
         type: "select",
-        options: ["small", "medium", "large", "xlarge"],
+        options: buttonSizes,
       },
     },
     color: {
-      description: "버튼의 색상 타입<br/>`String`",
-      table: {
-        type: {
-          summary: "목록",
-          detail: '"primary" "success" "gray" "error"',
-        },
-      },
+      description: "버튼의 색상 타입",
       control: {
         type: "select",
-        options: ["primary", "success", "gray", "error"],
+        options: buttonColors,
       },
     },
     type: {
-      description: "버튼의 타입<br/>`String`",
-      table: {
-        type: {
-          summary: "목록",
-          detail: '"fill" "outlined" "text"',
-        },
-      },
+      description: "버튼의 타입",
       control: {
         type: "select",
-        options: ["fill", "outlined", "text"],
+        options: buttonTypes,
       },
     },
     full: {
-      description: "버튼의 너비가 부모컴포넌트의 100%를 차지할지<br/>`Boolean`",
-      table: {
-        type: {
-          summary: null,
-        },
-      },
+      description: "width: 100%",
     },
     disabled: {
-      description: "버튼의 disabled 상태<br/>`Boolean`",
-      table: {
-        type: {
-          summary: null,
-        },
-      },
+      description: "버튼의 disabled 상태",
     },
     loading: {
-      description: "버튼의 loading 상태<br/>`Boolean`",
-      table: {
-        type: {
-          summary: null,
-        },
-      },
+      description: "버튼의 loading 상태",
+    },
+    fixed: {
+        description: "position: fixed"
+    },
+    absolute: {
+        description: "position: absolute"
+    },
+    shadow: {
+        description: "그림자"
     },
   }}
 />
@@ -86,7 +57,17 @@ export const Default = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { Button },
   template:
-    `<Button :size="size" :color="color" :type="type" :full="full" :disabled="disabled" :loading="loading">
+    `<Button
+        :size="size"
+        :color="color"
+        :type="type"
+        :full="full"
+        :disabled="disabled"
+        :loading="loading"
+        :absolute="absolute"
+        :fixed="fixed"
+        :shadow="shadow"
+    >
       {{label}}
     </Button>`,
 });


### PR DESCRIPTION
- color gray -> secondary로 변경
#### merge 오류로 재커밋
* [change] Icon spinner error color

* [change] xlarge일 때만 icon margin 4px로 변경

* [change] TextButton font-weight normal로 변경

* [change] Button 코드 개선

* [change] Button docs 개선

* [add] Button fixed, absolute props 추가

* [add] Button shadow props 추가

* [change] Box hasShadow -> shadow

* Revert "[change] Box hasShadow -> shadow"

This reverts commit e282a4be2c3f458553b765fbd35bc96a010006b5.

Co-authored-by: donghoon-song <thdehdgns@gmail.com>