### PR TITLE
Feature/add storybook deployer GitHub action

### DIFF
--- a/.github/workflows/storybook-deployer.yml
+++ b/.github/workflows/storybook-deployer.yml
@@ -1,4 +1,4 @@
-name: Storybook Deployer test
+name: Storybook Deployer
 on:
   pull_request:
     types:

--- a/.github/workflows/storybook-deployer.yml
+++ b/.github/workflows/storybook-deployer.yml
@@ -2,11 +2,11 @@ name: Storybook Deployer test
 on:
   pull_request:
     types:
-      - open
+      - closed
 jobs:
-  build:
-    name: Test
+  deploy_storybook:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'releases/v')
     steps:
       - uses: actions/checkout@v2
         with:
@@ -21,6 +21,6 @@ jobs:
           else
             npm install
           fi
-      - run: npm run deploy-storybook -- --ci --host-token-env-variable=GITHUB_TOKEN
+      - run: npm run deploy-storybook -- --ci --host-token-env-variable=STORYBOOK_DEPLOYER_TOKEN
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STORYBOOK_DEPLOYER_TOKEN: ${{ secrets.STORYBOOK_DEPLOYER_TOKEN }}


### PR DESCRIPTION
스토리북 배포 시 token이 포함되어 배포되는 문제를 해결했습니다. (github action으로 옮기고 token을 secret에서 불러옴)
배포할 때 shipjs랑 같이 병행으로 실행됩니다.