### PR TITLE
[fix] swiper.css에 있는 변수를 못 불러오는 이슈 해결

### DIFF
--- a/plugins/index.js
+++ b/plugins/index.js
@@ -1,1 +1,2 @@
 import './v-tooltip';
+import './vue-awesome-swiper';

--- a/plugins/vue-awesome-swiper.js
+++ b/plugins/vue-awesome-swiper.js
@@ -1,0 +1,2 @@
+// require styles
+import 'swiper/css/swiper.css';

--- a/src/Components/DataDisplay/Swiper.vue
+++ b/src/Components/DataDisplay/Swiper.vue
@@ -85,7 +85,6 @@
 import customValidator from '@/utils/custom-validator.js';
 import Icon from '@/src/Elements/Core/Icon/Icon';
 import { Swiper as BaseSwiper, SwiperSlide as BaseSwiperSlide } from 'vue-awesome-swiper';
-import 'swiper/css/swiper.css';
 
 export const SwiperControlsColors = ['light', 'dark'];
 export const SwiperControlPositions = ['inside', 'outside', 'top'];


### PR DESCRIPTION
swiper.css를 번들링할 때 포함시킴