### PR TITLE
[add] DatePicker 캘린더 width 100%, height 조정

### DIFF
--- a/src/Components/DataEntry/DatePicker.vue
+++ b/src/Components/DataEntry/DatePicker.vue
@@ -1,6 +1,7 @@
 <template>
 	<div class="c-application c-date-picker" :class="computedColor">
 		<date-picker
+			:ref="`datePicker${uid}`"
 			v-model="sync_value"
 			prefix-class="c"
 			type="date"
@@ -12,7 +13,10 @@
 			:class="computedClasses"
 			:editable="editable"
 			:clearable="clearable"
+			:popup-class="`c-calendar-${uid}`"
+			:open.sync="open"
 			v-on="$listeners"
+			@change="handleChange"
 		/>
 		<Hint :color="color" :value="hint" />
 	</div>
@@ -23,6 +27,7 @@
 import DatePicker from 'vue2-datepicker';
 import 'vue2-datepicker/locale/ko';
 import customValidator from '@/utils/custom-validator.js';
+import uniqueId from '@/utils/unique-id';
 import Hint from '../DataDisplay/Hint';
 
 export const valueTypes = ['format', 'date', 'timestamp'];
@@ -80,6 +85,12 @@ export default {
 			default: true,
 		},
 	},
+	data() {
+		return {
+			open: false,
+			uid: uniqueId(),
+		};
+	},
 	computed: {
 		sync_value: {
 			get() {
@@ -94,6 +105,32 @@ export default {
 		},
 		computedColor() {
 			return this.color;
+		},
+	},
+	watch: {
+		open() {
+			this.handleCalendarWidth();
+		},
+	},
+	methods: {
+		handleChange() {
+			this.open = false;
+		},
+		handleCalendarWidth() {
+			const $datePicker = this.$refs[`datePicker${this.uid}`];
+			const datePickerWidth = $datePicker.$el.clientWidth;
+
+			this.$nextTick(() => {
+				const calendarDefaultWidth = 248;
+				const calendarDefaultContentHeight = 224;
+				const $calendar = document.querySelector(`.c-calendar-${this.uid} > div > div > div`);
+				const $calendarContent = $calendar.lastChild;
+				$calendar.style.width = `${datePickerWidth}px`;
+
+				if (datePickerWidth > calendarDefaultWidth) {
+					$calendarContent.style.height = `${calendarDefaultContentHeight * 1.2}px`;
+				}
+			});
 		},
 	},
 	components: {


### PR DESCRIPTION
- 캘린더 width를 TextField와 동일하게 하기
- TextField width가 캘린더 기본 width(248px)보다 크면 기본 height(224px)를 1.2배 늘리기