### PR TITLE
Callout close 버튼 position, icon style mixin으로 변경

### DIFF
--- a/src/Components/Message/Callout.vue
+++ b/src/Components/Message/Callout.vue
@@ -124,6 +124,12 @@ export default {
 </script>
 
 <style scoped lang="scss">
+@mixin callout-icon-margin-right($margin-right) {
+	svg:first-child {
+		margin-right: $margin-right;
+	}
+}
+
 .c-callout {
 	&--container {
 		display: inline-flex;
@@ -131,30 +137,24 @@ export default {
 		&.full {
 			width: 100%;
 		}
-		svg {
+		svg:first-child {
 			flex-shrink: 0;
 		}
 
 		&.x-small {
 			padding: 4px 8px;
 			border-radius: 4px;
-			svg {
-				margin-right: 4px;
-			}
+			@include callout-icon-margin-right(4px);
 		}
 		&.small {
 			padding: 8px;
 			border-radius: 4px;
-			svg {
-				margin-right: 6px;
-			}
+			@include callout-icon-margin-right(6px);
 		}
 		&.medium {
 			padding: 16px 16px 16px 16px;
 			border-radius: 6px;
-			svg {
-				margin-right: 8px;
-			}
+			@include callout-icon-margin-right(8px);
 		}
 
 		// type

--- a/src/Components/Message/Callout.vue
+++ b/src/Components/Message/Callout.vue
@@ -186,8 +186,6 @@ export default {
 		}
 	}
 	&--close-button {
-		position: absolute;
-		right: 4px;
 		margin-left: 4px;
 	}
 }


### PR DESCRIPTION
- [x] 닫기버튼 position: relative로 변경
- [x] svg margin-right 스타일 코드를 mixin으로 변경 (svg로 잡혀있어서 close icon도 영향을 받고 있어서 `:first-child`를 추가)