### PR TITLE
[add] Callout icon slot, mdx 추가

### DIFF
--- a/src/Components/Message/Callout.vue
+++ b/src/Components/Message/Callout.vue
@@ -7,10 +7,16 @@
 			v-on="$listeners"
 		>
 			<div class="c-callout--wrapper">
-				<Icon :name="mapIconNameFromSize(size)" :color="computedIconColor" />
+				<!-- 아이콘 -->
+				<slot v-if="$slots['icon']" name="icon" />
+				<Icon v-else :name="mapIconNameFromSize(size)" :color="computedIconColor" />
+
+				<!-- 문구 -->
 				<Typography class="c-callout--message" color="gray700" :type="computedFontType">
 					<slot />
 				</Typography>
+
+				<!-- 닫기 -->
 				<Icon
 					v-if="closable"
 					class="c-callout--close-button"
@@ -125,7 +131,8 @@ export default {
 
 <style scoped lang="scss">
 @mixin callout-icon-margin-right($margin-right) {
-	svg:first-child {
+	::v-deep svg:first-child {
+		overflow: inherit; //overflow: hidden 때문에 margin을 주면 아이콘이 짤려서 추가함
 		margin-right: $margin-right;
 	}
 }

--- a/stories/Callout/Callout.stories.mdx
+++ b/stories/Callout/Callout.stories.mdx
@@ -1,5 +1,6 @@
 import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import Callout, { CalloutTypes, CalloutSizes } from "@/src/Components/Message/Callout";
+import Icon from '@/src/Elements/Core/Icon/Icon';
 
 <Meta
   title="Message/Callout"
@@ -131,9 +132,20 @@ export const Default = (args, { argTypes }) => ({
                     <Callout v-if="showMediumCallout" size="medium" closable @closeCallout="showMediumCallout = false">문구가 들어가는 자리입니다.</Callout>
                 </div>
             </div>
+            <div style="margin-bottom: 10px">
+                <div>
+                    <Callout size="medium">
+                        <template v-slot:icon>
+                            <Icon name="IconVideoLargeFill" color="gray850" />
+                        </template>
+                        1주차 세션 종료 후,<br />
+                        복습을 위한 VOD가 제공됩니다.
+                    </Callout>
+                </div>
+            </div>
         </div>
             `,
-      components: { Callout },
+      components: { Callout, Icon },
     }}
   </Story>
 </Canvas>
@@ -233,6 +245,43 @@ export const Default = (args, { argTypes }) => ({
             </div>
             `,
         components: { Callout },
+    }}
+    </Story>
+</Canvas>
+
+### Icon
+<Canvas>
+    <Story name="Icon" height="100px">
+    {{
+        data() {
+            return {
+                showXSmallCallout: true,
+                showSmallCallout: true,
+                showMediumCallout: true,
+            }
+        },
+        template: `
+            <div>
+                <div>
+                    <Callout size="small" type="success">
+                        <template v-slot:icon>
+                            <Icon name="IconCheckRoundMediumLine" />
+                        </template>
+                        문구가 들어가는 자리입니다.
+                    </Callout>
+                </div>
+                <div>
+                    <Callout size="medium">
+                        <template v-slot:icon>
+                            <Icon name="IconVideoLargeFill" color="gray850" />
+                        </template>
+                        1주차 세션 종료 후,<br />
+                        복습을 위한 VOD가 제공됩니다.
+                    </Callout>
+                </div>
+            </div>
+            `,
+        components: { Callout, Icon },
     }}
     </Story>
 </Canvas>


### PR DESCRIPTION
1. Callout에 icon의 자율성이 필요한 상황이 생겨서 Icon slot이 없을 때는 기존 아이콘, 있으면 slot이 나오도록 변경했습니다.
![스크린샷 2021-02-17 오후 2 59 44](https://user-images.githubusercontent.com/19399338/108162604-c9074d80-7130-11eb-9c24-2c9bfa908d45.png)

2. slot icon에 margin을 추가하면 아이콘이 짤리는 현상이 있어서 `overflow: inherit`를 추가했습니다.
