### PR TITLE
Callout css 추가

### DIFF
--- a/src/Components/Message/Callout.vue
+++ b/src/Components/Message/Callout.vue
@@ -185,6 +185,7 @@ export default {
 	&--message {
 		width: 100%;
 		word-break: keep-all;
+		white-space: normal;
 		&::v-deep strong {
 			@include f-normal();
 		}

--- a/src/Components/Message/Callout.vue
+++ b/src/Components/Message/Callout.vue
@@ -134,6 +134,7 @@ export default {
 	::v-deep svg:first-child {
 		overflow: inherit; //overflow: hidden 때문에 margin을 주면 아이콘이 짤려서 추가함
 		margin-right: $margin-right;
+		cursor: auto;
 	}
 }
 


### PR DESCRIPTION
- message영역 `white-space: normal` 추가  (탭 영역이 공백으로 잡히는 이슈)
- 왼쪽 icon `cursor: auto` 추가 (클릭 이벤트가 없는데 포인터 커서로 보이는 이슈)