### PR TITLE
TextField active color 오류 수정 및 로직개선(hint, focus 로직 개선) 및 persistentHint props 추가

### DIFF
--- a/src/Components/DataEntry/TextField.vue
+++ b/src/Components/DataEntry/TextField.vue
@@ -198,27 +198,27 @@ export default {
 			&.active {
 				border-color: $secondary;
 			}
-			&.error,
-			&.active {
-				&:focus {
+			&.error {
+				&:focus,
+				&.active {
 					border-color: $error;
 				}
 			}
-			&.primary,
-			&.active {
-				&:focus {
+			&.primary {
+				&:focus,
+				&.active {
 					border-color: $primary;
 				}
 			}
-			&.success,
-			&.active {
-				&:focus {
+			&.success {
+				&:focus,
+				&.active {
 					border-color: $success;
 				}
 			}
-			&.secondary,
-			&.active {
-				&:focus {
+			&.secondary {
+				&:focus,
+				&.active {
 					border-color: $secondary;
 				}
 			}

--- a/src/Components/DataEntry/TextField.vue
+++ b/src/Components/DataEntry/TextField.vue
@@ -9,7 +9,6 @@
 			:name="computedId"
 			:label="label"
 			:align="align"
-			:focus="focus"
 			:readonly="readonly"
 			:disabled="disabled"
 			:color="color"
@@ -78,10 +77,6 @@ export default {
 				}
 				return isValid;
 			},
-		},
-		focus: {
-			type: Boolean,
-			default: false,
 		},
 		readonly: {
 			type: Boolean,
@@ -153,13 +148,6 @@ export default {
 		computedActive() {
 			return { active: this.active };
 		},
-	},
-
-	mounted() {
-		if (this.focus) {
-			this.$refs[this.computedId].focus();
-			this.$refs[this.computedId].parentElement.classList.add('active');
-		}
 	},
 	methods: {
 		handleTyping(e) {

--- a/src/Components/DataEntry/TextField.vue
+++ b/src/Components/DataEntry/TextField.vue
@@ -17,11 +17,11 @@
 			v-bind="$attrs"
 			@input="handleTyping"
 			v-on="$listeners"
-			@focusin="hintColor = color"
-			@focusout="hintColor = 'secondary'"
+			@focus="onFocus"
+			@blur="blurFocus"
 		/>
 		<label v-if="computedShowLabel" :for="computedId" class="c-text-field--label">{{ label }}</label>
-		<Hint :value="hint" :color="active ? color : hintColor" />
+		<Hint v-if="computedShowHint" :value="hint" :color="color" />
 	</div>
 </template>
 
@@ -100,13 +100,17 @@ export default {
 			type: String,
 			default: '',
 		},
+		persistentHint: {
+			type: Boolean,
+			default: false,
+		},
 		full: {
 			type: Boolean,
 			default: false,
 		},
 	},
 	data: () => ({
-		hintColor: 'secondary',
+		isFocused: false,
 	}),
 	computed: {
 		sync_value: {
@@ -114,7 +118,6 @@ export default {
 				return this.value;
 			},
 			set(val) {
-				this.hintColor = this.color;
 				this.$emit('update:value', val);
 			},
 		},
@@ -130,6 +133,9 @@ export default {
 		},
 		computedShowLabel() {
 			return this.label;
+		},
+		computedShowHint() {
+			return !!this.hint && (this.persistentHint || this.isFocused || this.active);
 		},
 		computedLabel() {
 			return { label: this.computedShowLabel };
@@ -152,6 +158,12 @@ export default {
 	methods: {
 		handleTyping(e) {
 			this.sync_value = e.target.value;
+		},
+		onFocus() {
+			this.isFocused = true;
+		},
+		blurFocus() {
+			this.isFocused = false;
 		},
 	},
 	components: { Hint },

--- a/stories/DataEntry/Textfield.stories.mdx
+++ b/stories/DataEntry/Textfield.stories.mdx
@@ -1,5 +1,6 @@
 import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import TextField, { TextFieldTypes, TextFieldAligns, TextFieldColor } from "@/src/Components/DataEntry/TextField";
+import Typography from '@/src/Elements/Core/Typography/Typography';
 
 <Meta
     title="Data Entry/TextField"
@@ -112,7 +113,6 @@ export const Default = (args, { argTypes }) => ({
 
 ## Stories
 ### Hint default
-
 <Canvas>
     <Story name="Hint Default" height="200px">
         {{
@@ -212,7 +212,6 @@ export const Default = (args, { argTypes }) => ({
 </Canvas>
 
 ### Hint Success
-
 <Canvas>
     <Story name="Hint Success" height="200px">
         {{
@@ -262,7 +261,6 @@ export const Default = (args, { argTypes }) => ({
 </Canvas>
 
 ### Hint Primary
-
 <Canvas>
     <Story name="Hint Primary" height="200px">
         {{
@@ -312,7 +310,6 @@ export const Default = (args, { argTypes }) => ({
 </Canvas>
 
 ### Full
-
 <Canvas>
     <Story name="Full" height="200px">
         {{
@@ -330,6 +327,40 @@ export const Default = (args, { argTypes }) => ({
                 </div>
             `,
             components: { TextField },
+        }}
+    </Story>
+</Canvas>
+
+### Validate
+<Canvas>
+    <Story name="Validate" height="200px">
+        {{
+            template: `
+                <div>
+                    <Typography type="body2" color="gray500" class="mb-4">이름</Typography>
+                    <TextField
+                        type="text"
+                        :color="isError ? 'error' : 'secondary'"
+                        :hint="isError ? '두 글자 이상 입력해 주세요.' : '실명을 입력하세요. 입력된 이름으로 수료증이 발급됩니다.'"
+                        outlined
+                        placeholder="코멘티"
+                        :active="isError"
+                        :value.sync="name"
+                    />
+                </div>
+            `,
+            data() {
+                return {
+                    name: null,
+                    isError: false,
+                };
+            },
+            watch: {
+                name() {
+                    this.isError = this.name.length < 2;
+                }
+            },
+            components: { TextField, Typography },
         }}
     </Story>
 </Canvas>


### PR DESCRIPTION
- `.active` 하위 `:focus` 때문에 색상이 적용 안 되는 오류
- `persistentHint` props 추가
- `focus` props 제거
- hint 로직 개선 (`hint`가 있고 `persisteneHint`거나, focus되어있거나, `active`인 경우)
- validate mdx 스토리 추가 