### PR TITLE
[fix] created 로직을 watch로 이동

### DIFF
--- a/src/Components/DataEntry/Select.vue
+++ b/src/Components/DataEntry/Select.vue
@@ -135,12 +135,17 @@ export default {
 			return this.options.every(option => typeof option === 'object');
 		},
 	},
-	created() {
+	watch: {
 		// 초기 렌더링 시 object option을 가지고 있어도 select를 하기 전 value 그대로 노출되는 이슈 해결
-		if (this.hasObjectOptions) {
-			const option = this.options.find(option => option.value === this.value);
-			this.handleSelect(option);
-		}
+		hasObjectOptions: {
+			immediate: true,
+			handler(newVal) {
+				if (newVal) {
+					const option = this.options.find(option => option.value === this.value);
+					this.handleSelect(option);
+				}
+			},
+		},
 	},
 	methods: {
 		handleOptions(option, type) {


### PR DESCRIPTION
created에서 처리하면 props가 변경되는 (ex. computed props) 상황에서 적용이 안됨