### PR TITLE
[add] Table 컴포넌트, mdx 추가

### DIFF
--- a/src/Components/DataDisplay/Table.vue
+++ b/src/Components/DataDisplay/Table.vue
@@ -1,0 +1,109 @@
+<template>
+	<div>
+		<div class="c-application c-table" :class="classes">
+			<!-- head -->
+			<div class="c-table--head">
+				<slot name="head" />
+			</div>
+
+			<!-- body -->
+			<slot v-if="$slots['body']" name="body" />
+		</div>
+
+		<!-- empty -->
+		<div v-if="$slots['empty']" class="c-table--empty">
+			<slot name="empty" />
+		</div>
+	</div>
+</template>
+
+<script>
+export const cursors = ['pointer', 'default'];
+
+export default {
+	name: 'Table',
+	props: {
+		cursor: {
+			type: String,
+			default: 'default',
+			validator(value) {
+				return cursors.indexOf(value) !== -1;
+			},
+		},
+	},
+	computed: {
+		classes() {
+			return [this.computedCursor];
+		},
+		computedCursor() {
+			return `c-${this.cursor}`;
+		},
+	},
+};
+</script>
+
+<style lang="scss" scoped>
+$tablePaddingX: 12px;
+
+.c-table {
+	display: table;
+	width: 100%;
+	table-layout: auto;
+	border-collapse: collapse;
+
+	&--head {
+		display: table-row;
+		text-align: center;
+		border-bottom: 1px solid $gray200;
+
+		> * {
+			@include caption1();
+			color: $gray400 !important;
+			display: table-cell;
+			padding: 12px 6px;
+			&:first-child {
+				padding-left: $tablePaddingX;
+			}
+			&:last-child {
+				padding-right: $tablePaddingX;
+			}
+		}
+	}
+
+	// table body
+	> ul {
+		display: table-row;
+		border-bottom: 1px solid $gray100;
+
+		> li {
+			display: table-cell;
+			text-align: center;
+			vertical-align: middle;
+			padding: 18px 6px;
+			&:first-child {
+				padding-left: $tablePaddingX;
+			}
+			&:last-child {
+				padding-right: $tablePaddingX;
+			}
+
+			> div,
+			button {
+				display: block;
+			}
+		}
+	}
+
+	&.c-pointer {
+		> ul > li {
+			cursor: pointer;
+		}
+	}
+
+	&--empty {
+		padding: 40px 0;
+		@include flexbox();
+		@include justify-content(center);
+	}
+}
+</style>

--- a/src/Components/DataDisplay/index.js
+++ b/src/Components/DataDisplay/index.js
@@ -12,6 +12,7 @@ import Hint from './Hint';
 import List from './List';
 import ListItem from './ListItem';
 import Swiper from './Swiper';
+import Table from './Table';
 import Tabs from './Tabs';
 
 export {
@@ -29,6 +30,7 @@ export {
 	List,
 	ListItem,
 	Swiper,
+	Table,
 	Tabs,
 };
 export * from './Drawer';

--- a/stories/DataDisplay/Table.stories.mdx
+++ b/stories/DataDisplay/Table.stories.mdx
@@ -1,0 +1,210 @@
+import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import Table from "@/src/Components/DataDisplay/Table";
+import Typography from "@/src/Elements/Core/Typography/Typography";
+import Divider from "@/src/Elements/Utility/Divider";
+import ListItem from "@/src/Components/DataDisplay/ListItem";
+import List from "@/src/Components/DataDisplay/List";
+import Button from "@/src/Components/Button/Button";
+import LinkButton from "@/src/Components/Button/LinkButton";
+import Grid from "@/src/Components/Layout/Grid";
+import Row from "@/src/Components/Layout/Row";
+import StyleCol from "@/src/Components/Layout/StyleCol";
+
+<Meta
+    title="Data Display/Table"
+    component={ Table }
+    argTypes={{}}
+/>
+
+
+# Table
+**Table** 컴포넌트의 문서입니다.
+
+
+## Stories
+### All
+<Canvas>
+    <Story name="All" height="100px">
+        {{
+            components: { Table, Typography, Divider, List, ListItem, Button, Grid, Row, StyleCol },
+            data() {
+                return {
+                    tableHeadItems1: ["직무", "캠프명", "만족도", "시작일", "신청"],
+                    tableBodyItems1: [
+                        {
+                            job: '기획',
+                            title: '[5차 앵콜] 대형마트 신선식품 바이어(MD)의 매출분석, 행사기획, 상품개발 실무체험',
+                            score: '4.8',
+                            start_at: '2021. 02. 08'
+                        },
+                        {
+                            job: '영업/고객상담',
+                            title: '[11차 앵콜] 해외영업 현직자와 함께 시장분석부터 전략수립까지! 직무 역량 쌓기!',
+                            score: '4.5',
+                            start_at: '2021. 02. 08'
+                        },
+                    ],
+                    tableHeadItems2: ["구분", "작성자", "차수", "제출일시", "피드백"],
+                    tableBodyItems2: [
+                        {
+                            name: '유성실',
+                            week: '2',
+                            created_at: '2020. 08. 20<br />20시 32분',
+                            state: '대기',
+                        },
+                        {
+                            name: '송동훈',
+                            week: '1',
+                            created_at: '2020. 08. 11<br />22시 32분',
+                            state: '완료',
+                        },
+                        {
+                            name: '김하나',
+                            week: '1',
+                            created_at: '2020. 08. 11<br />20시 32분',
+                            state: '완료',
+                        },
+                        {
+                            name: '유성실',
+                            week: '1',
+                            created_at: '2020. 08. 10<br />20시 32분',
+                            state: '완료',
+                        },
+                    ],
+                };
+            },
+            template:
+                `<Grid>
+                    <Row class="mb-60">
+                        <StyleCol :col-lg="12" :col-sm="12" col-gutters>
+                            <Table>
+                                <template v-slot:head>
+                                    <Typography
+                                        type="body2"
+                                        color="gray800"
+                                        v-for="(head, index) in tableHeadItems1"
+                                        :key="'table-head-'+index"
+                                        :class="{'text-left': index === 1}"
+                                    >
+                                        {{ head }}
+                                    </Typography>
+                                </template>
+                                <template v-slot:body>
+                                    <template v-for="item in tableBodyItems1">
+                                        <ul>
+                                            <li>
+                                                <Typography type="body2">{{ item.job }}</Typography>
+                                            </li>
+                                            <li>
+                                                <Typography type="body2" align="left" color="gray800">{{ item.title }}</Typography>
+                                            </li>
+                                            <li>
+                                                <Typography type="body2" color="gray500" style="display: flex; justify-content: center">
+                                                    <Typography color="primary">{{ item.score }}</Typography>/5
+                                                </Typography>
+                                            </li>
+                                            <li>
+                                                <Typography type="body2" color="gray600">
+                                                    {{ item.start_at }}
+                                                </Typography>
+                                            </li>
+                                            <li>
+                                                <Button type="outlined" color="secondary" size="small" style="margin: 0 auto">신청하기</Button>
+                                            </li>
+                                        </ul>
+                                    </template>
+                                </template>
+                            </Table>
+                        </StyleCol>
+                    </Row>
+                    <Row>
+                        <StyleCol :col-lg="4" :col-sm="12" :offset-lg="isMobile ? 0 : 4" col-gutters>
+                            <Table>
+                                <template v-slot:head>
+                                    <Typography
+                                        type="body2"
+                                        color="gray800"
+                                        v-for="(head, index) in tableHeadItems2"
+                                        :key="'table-head-'+index"
+                                        :class="{'text-left': index === 1 || index === 3}"
+                                    >
+                                        {{ head }}
+                                    </Typography>
+                                </template>
+                                <template v-slot:body>
+                                    <template v-for="(item, index) in tableBodyItems2">
+                                        <ul>
+                                            <li>
+                                                <Typography type="body2">{{ index + 1 }}</Typography>
+                                            </li>
+                                            <li>
+                                                <Typography type="body2" align="left" color="gray800">{{ item.name }}</Typography>
+                                            </li>
+                                            <li>
+                                                <Typography type="body2" color="gray600">
+                                                    {{ item.week }}차
+                                                </Typography>
+                                            </li>
+                                            <li>
+                                                <Typography type="caption1" color="gray600" class="text-left" v-html="item.created_at" />
+                                            </li>
+                                            <li>
+                                                <Button
+                                                    type="outlined"
+                                                    color="secondary"
+                                                    size="small"
+                                                    style="margin: 0 auto"
+                                                >
+                                                    {{item.state}}
+                                                </Button>
+                                            </li>
+                                        </ul>
+                                    </template>
+                                </template>
+                            </Table>
+                        </StyleCol>
+                    </Row>
+                </Grid>`,
+        }}
+    </Story>
+</Canvas>
+
+### Empty
+<Canvas>
+    <Story name="Empty" height="100px">
+        {{
+            components: { Table, Typography, LinkButton, Grid, Row, StyleCol },
+            data() {
+                return {
+                    tableHeadItems: ["구분", "작성자", "차수", "제출일시", "피드백"],
+                };
+            },
+            template:
+                `<Grid>
+                    <Row>
+                        <StyleCol :col-lg="4" :col-sm="12" :offset-lg="isMobile ? 0 : 4" col-gutters>
+                            <Table>
+                                <template v-slot:head>
+                                    <Typography
+                                        type="body2"
+                                        color="gray800"
+                                        v-for="(head, index) in tableHeadItems"
+                                        :key="'table-head-'+index"
+                                        :class="{'text-left': index === 1 || index === 3}"
+                                    >
+                                        {{ head }}
+                                    </Typography>
+                                </template>
+                                <template v-slot:empty>
+                                    <Typography type="body2" color="gray700">
+                                        아직 과제가 제출되지 않았어요 :(<br />
+                                        <LinkButton type="body2" style="display: inline-flex">여기</LinkButton>를 눌러 과제를 제출하세요!
+                                    </Typography>
+                                </template>
+                            </Table>
+                        </StyleCol>
+                    </Row>
+                </Grid>`,
+        }}
+    </Story>
+</Canvas>


### PR DESCRIPTION
- **유연하게 사용**하기 위해 대부분의 구조를 slot으로 나누었으며, props는 최소화했습니다.
- 테이블 각종 여백, head영역의 글자 크기와 색상은 고정값입니다. (디자이너 컨펌 완료)
- 모바일에서 공간이 충분치 않을 경우, PC에서만 디자인시스템을 사용하며 모바일은 따로 코딩합니다.

## slot
slot은 총 3개입니다. (head, body, empty)
- head: 테이블 타이틀 영역입니다.
- body: 테이블 콘텐츠 영역입니다. (* **ul > li 구조로 작업**해야 합니다.)
- empty: 테이블 콘텐츠가 없을 때 노출되는 영역입니다.
## props
- cursor: 테이블 콘텐츠 영역 row에 대한 커서 모양입니다. (default, pointer)
## 주요 사용법
1. align: 기본은 center이고 left, right를 사용하려면 특정 태그에 class를 추가합니다. (`text-left`, `text-right`)
2. 클릭이벤트: 특정 태그내에서 @click으로 사용합니다. (`<li @click="클릭이벤트">콘텐츠</li>`)
3. 특정 컬럼의 width: 특정 태그에서 style을 추가합니다.

궁금한 점이 있다면 멘션하여 댓글 달아주세요.