### PR TITLE
Checkbox size prop (xsmall, small, medium)

### DIFF
--- a/src/Components/DataEntry/Checkbox.vue
+++ b/src/Components/DataEntry/Checkbox.vue
@@ -95,7 +95,7 @@ export default {
 		},
 		computedTypographyType() {
 			const sizeForTypeList = {
-				small: 'caption1',
+				small: 'body2',
 				medium: 'body1',
 			};
 			return sizeForTypeList[this.size];
@@ -156,7 +156,7 @@ export default {
 		& + label {
 			display: inline-flex;
 			flex-direction: row;
-			align-items: center;
+			align-items: flex-start;
 			cursor: pointer;
 			> div {
 				display: inline-block;
@@ -169,6 +169,7 @@ export default {
 				border: 1px solid $input-border-color;
 				border-radius: 2px;
 				display: inline-block;
+				margin-top: 3px;
 				margin-right: 8px;
 				box-sizing: border-box;
 			}
@@ -177,25 +178,9 @@ export default {
 
 	&.small {
 		input[type='checkbox'] {
-			& + label {
-				display: inline-flex;
-				flex-direction: row;
-				align-items: center;
-				cursor: pointer;
-				> div {
-					display: inline-block;
-				}
-				&:before {
-					width: 16px;
-					height: 16px;
-					content: '';
-					background-color: $gray000;
-					border: 1px solid $input-border-color;
-					border-radius: 2px;
-					display: inline-block;
-					margin-right: 8px;
-					box-sizing: border-box;
-				}
+			& + label:before {
+				width: 16px;
+				height: 16px;
 			}
 		}
 	}

--- a/src/Components/DataEntry/Checkbox.vue
+++ b/src/Components/DataEntry/Checkbox.vue
@@ -20,7 +20,7 @@
 import { colorKeys } from '@/src/Elements/Core/Colors';
 import Typography from '@/src/Elements/Core/Typography/Typography';
 import uniqueId from '@/utils/unique-id';
-export const checkboxSizes = ['small', 'medium'];
+export const checkboxSizes = ['xsmall', 'small', 'medium'];
 
 export default {
 	name: 'Checkbox',
@@ -95,6 +95,7 @@ export default {
 		},
 		computedTypographyType() {
 			const sizeForTypeList = {
+				xsmall: 'caption1',
 				small: 'body2',
 				medium: 'body1',
 			};
@@ -166,6 +167,7 @@ export default {
 				height: 20px;
 				content: '';
 				background-color: $gray000;
+				background-position: center center;
 				border: 1px solid $input-border-color;
 				border-radius: 2px;
 				display: inline-block;
@@ -179,8 +181,27 @@ export default {
 	&.small {
 		input[type='checkbox'] {
 			& + label:before {
-				width: 16px;
-				height: 16px;
+				width: 18px;
+				height: 18px;
+				margin-top: 2px;
+				background-size: 16px;
+			}
+		}
+	}
+
+	&.xsmall {
+		input[type='checkbox'] {
+			& + label {
+				> div {
+					margin-top: 2px;
+				}
+				&:before {
+					margin-top: 0;
+					margin-right: 6px;
+					width: 16px;
+					height: 16px;
+					background-size: 14px;
+				}
 			}
 		}
 	}

--- a/src/Components/DataEntry/Checkbox.vue
+++ b/src/Components/DataEntry/Checkbox.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="c-application c-checkbox">
+	<div class="c-application c-checkbox" :class="computedClasses">
 		<input
 			:id="computedId"
 			v-model="sync_value"
@@ -9,7 +9,7 @@
 			v-on="$listeners"
 		/>
 		<label :class="{ disabled }" :for="computedId">
-			<Typography :color="computedColor">
+			<Typography :color="computedColor" :type="computedTypographyType">
 				<slot />
 			</Typography>
 		</label>
@@ -20,6 +20,7 @@
 import { colorKeys } from '@/src/Elements/Core/Colors';
 import Typography from '@/src/Elements/Core/Typography/Typography';
 import uniqueId from '@/utils/unique-id';
+export const checkboxSizes = ['small', 'medium'];
 
 export default {
 	name: 'Checkbox',
@@ -57,6 +58,17 @@ export default {
 				return isValid;
 			},
 		},
+		size: {
+			type: String,
+			default: 'medium',
+			validator(value) {
+				const isValid = checkboxSizes.indexOf(value) !== -1;
+				if (!isValid) {
+					console.error(`${value} is not a valid value of the Checkbox size`);
+				}
+				return isValid;
+			},
+		},
 	},
 	data() {
 		return {
@@ -77,6 +89,16 @@ export default {
 		},
 		computedColor() {
 			return this.disabled ? 'gray300' : this.color;
+		},
+		computedClasses() {
+			return [this.size];
+		},
+		computedTypographyType() {
+			const sizeForTypeList = {
+				small: 'caption1',
+				medium: 'body1',
+			};
+			return sizeForTypeList[this.size];
 		},
 	},
 	components: { Typography },
@@ -149,6 +171,31 @@ export default {
 				display: inline-block;
 				margin-right: 8px;
 				box-sizing: border-box;
+			}
+		}
+	}
+
+	&.small {
+		input[type='checkbox'] {
+			& + label {
+				display: inline-flex;
+				flex-direction: row;
+				align-items: center;
+				cursor: pointer;
+				> div {
+					display: inline-block;
+				}
+				&:before {
+					width: 16px;
+					height: 16px;
+					content: '';
+					background-color: $gray000;
+					border: 1px solid $input-border-color;
+					border-radius: 2px;
+					display: inline-block;
+					margin-right: 8px;
+					box-sizing: border-box;
+				}
 			}
 		}
 	}

--- a/stories/DataEntry/Checkbox.stories.mdx
+++ b/stories/DataEntry/Checkbox.stories.mdx
@@ -1,5 +1,5 @@
 import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
-import Checkbox from "@/src/Components/DataEntry/Checkbox";
+import Checkbox, { checkboxSizes } from "@/src/Components/DataEntry/Checkbox";
 
 <Meta
     title="Data Entry/Checkbox"
@@ -21,6 +21,13 @@ import Checkbox from "@/src/Components/DataEntry/Checkbox";
         id: {
             description: "체크박스 ID (값이 없으면 input-uid로 생성됨)",
             control: { type: "text" },
+        },
+        size: {
+            description: "체크박스 크기",
+            control: {
+                type: "select",
+                options: checkboxSizes,
+            },
         }
     }}
 />
@@ -30,7 +37,7 @@ export const Default = (args, { argTypes }) => ({
     props: Object.keys(argTypes),
     components: { Checkbox },
     template:
-        `<Checkbox :value.sync="value" :disabled="disabled" :id="id">{{label}}</Checkbox>`,
+        `<Checkbox :value.sync="value" :disabled="disabled" :id="id" :size="size">{{label}}</Checkbox>`,
 });
 
 # Checkbox
@@ -51,10 +58,18 @@ export const Default = (args, { argTypes }) => ({
         {{
             template: `
                 <div>
-                    <Checkbox :value="false">Unchecked</Checkbox>
-                    <Checkbox :value="true">Checked</Checkbox>
-                    <Checkbox disabled>Unchecked Disabled</Checkbox>
-                    <Checkbox :value="true" disabled>Checked Disabled</Checkbox>
+                    <div>
+                        <h3>State</h3>
+                        <Checkbox :value="false">Unchecked</Checkbox>
+                        <Checkbox :value="true">Checked</Checkbox>
+                        <Checkbox disabled>Unchecked Disabled</Checkbox>
+                        <Checkbox :value="true" disabled>Checked Disabled</Checkbox>
+                    </div>
+                    <div class="mt-20">
+                        <h3>Size</h3>
+                        <Checkbox size="medium">Medium Size</Checkbox>
+                        <Checkbox size="small">Small Size</Checkbox>
+                    </div>
                 </div>
             `,
             components: { Checkbox },

--- a/stories/DataEntry/Checkbox.stories.mdx
+++ b/stories/DataEntry/Checkbox.stories.mdx
@@ -67,8 +67,8 @@ export const Default = (args, { argTypes }) => ({
                     </div>
                     <div class="mt-20">
                         <h3>Size</h3>
-                        <Checkbox size="medium">Medium Size</Checkbox>
-                        <Checkbox size="small">Small Size</Checkbox>
+                        <Checkbox size="medium" class="mb-4">Medium<br />Size</Checkbox>
+                        <Checkbox size="small">Small<br/>Size</Checkbox>
                     </div>
                 </div>
             `,

--- a/stories/DataEntry/Checkbox.stories.mdx
+++ b/stories/DataEntry/Checkbox.stories.mdx
@@ -68,7 +68,8 @@ export const Default = (args, { argTypes }) => ({
                     <div class="mt-20">
                         <h3>Size</h3>
                         <Checkbox size="medium" class="mb-4">Medium<br />Size</Checkbox>
-                        <Checkbox size="small">Small<br/>Size</Checkbox>
+                        <Checkbox size="small" class="mb-4">Small<br/>Size</Checkbox>
+                        <Checkbox size="xsmall">Xsmall<br/>Size</Checkbox>
                     </div>
                 </div>
             `,


### PR DESCRIPTION
size prop: string (xsmall, small, medium)
size는 label Typography type에 영향을 준다. (xsmall: caption1, small: body2, medium: body1)

텍스트랑 체크박스 위치잡는게 까다로워서 size별로 하드코딩 되어있는데, 개선가능할 지 피드백 부탁드려요!