### PR TITLE
quill-editor 커스텀 스타일 코드 추가 (콘텐츠용 스타일, header 한글화)

### DIFF
--- a/assets/style/quill/quill.init.scss
+++ b/assets/style/quill/quill.init.scss
@@ -121,6 +121,33 @@
 
   .ql-picker.ql-header {
     width: 65px;
+
+    .ql-picker-item:before,
+    .ql-picker-label:before {
+      content: '본문1';
+      position: relative;
+      top: -2px;
+    }
+    .ql-picker-item[data-value='1']:before,
+    .ql-picker-label[data-value='1']:before {
+      content: '제목1';
+    }
+    .ql-picker-item[data-value='2']:before,
+    .ql-picker-label[data-value='2']:before {
+      content: '제목2';
+    }
+    .ql-picker-item[data-value='3']:before,
+    .ql-picker-label[data-value='3']:before {
+      content: '제목3';
+    }
+    .ql-picker-item[data-value='5']:before,
+    .ql-picker-label[data-value='5']:before {
+      content: '본문2';
+    }
+    .ql-picker-item[data-value='6']:before,
+    .ql-picker-label[data-value='6']:before {
+      content: '캡션';
+    }
   }
 
   .ql-tooltip {

--- a/assets/style/quill/quill.init.scss
+++ b/assets/style/quill/quill.init.scss
@@ -24,6 +24,11 @@
   color: $gray800;
   @include body1;
 
+  &-content {
+    min-height: auto;
+    height: auto;
+  }
+
   &.ql-blank::before {
     color: $gray300;
     font-style: normal;


### PR DESCRIPTION
# 1. 콘텐츠용 스타일 추가 (`.ql-editor-content`)
사용방법: `<div class="ql-editor ql-editor-content">내용</div>`
## 😭  이슈
`.ql-editor`에 있는 스타일 때문에 VED의 UI가 영향을 받고 있음

```scss
.ql-editor {
	min-height: 100px; // 추가 스타일
	height: 100%; // 기본 스타일
}

```
<img width="801" alt="스크린샷 2021-04-08 오후 7 17 58" src="https://user-images.githubusercontent.com/19399338/114010523-22713a80-989f-11eb-94f9-b9ab3166bb5f.png">

## 😍 솔루션
- 현재 `.ql-editor`에 적용된 스타일은 그대로 유지한다.
    - `.ql-editor`에서 `height: 100%`를 제거하지 않는다.

        기본 스타일이며, 딱히 없앨만한 이유가 없다.

    - `.ql-editor`에서 `min-height: 100px`를 제거하지 않는다.

        모든 에디터에 최소 높이가 있는 것이 우리가 원하는 사양이기 때문이다.

- 에디터 콘텐츠를 위해 추가 클래스(`.ql-editor-content`)를 사용한다.

    ```scss
    .ql-editor {
    	&-content {	
    		min-height: auto;
    		height: auto;
    	}
    }
    ```

    ```html
    <div class="ql-editor ql-editor-content" />
    ```
# 2. header 한글화
![스크린샷 2021-04-08 오후 7 21 09](https://user-images.githubusercontent.com/19399338/114010912-96134780-989f-11eb-8e99-a7a243e70ceb.png)
