### PR TITLE
[fix] callout 전체에 대한 click event가 close button에도 전달되는 것을 방지

### DIFF
--- a/src/Components/Message/Callout.vue
+++ b/src/Components/Message/Callout.vue
@@ -21,7 +21,7 @@
 					v-if="closable"
 					class="c-callout--close-button"
 					:name="computedCloseIconName"
-					@click="handleClose"
+					@click.stop.capture="handleClose"
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
현재는 close button을 누르면 callout의 click listener까지 발동되는데
수정 버전은 close listener만 실행