### PR TITLE
[change] NewGrid max-width: 100vw로 변경

### DIFF
--- a/src/Components/Layout/NewGrid.vue
+++ b/src/Components/Layout/NewGrid.vue
@@ -50,7 +50,7 @@ export default {
 		padding: 0;
 	}
 	&.container {
-		max-width: $container-max-width-mobile;
+		max-width: 100vw;
 		@include pc {
 			max-width: $container-max-width-pc;
 		}


### PR DESCRIPTION
## 문제 상황
모바일에서 `max-width: 375px`로 고정되어있어서 iPhone 6/7/8 Plus에서는 양쪽여백이 넓게 잡힘
![image](https://user-images.githubusercontent.com/16662430/116049788-aa35b200-a6b1-11eb-80bb-d09c484f578b.png)
## 해결 방법
`max-width: 100vw`로 변경