### PR TITLE
[fix] Avatar height가 클 때 레이아웃 깨지는 오류 수정

### DIFF
--- a/src/Components/DataDisplay/Avatar.vue
+++ b/src/Components/DataDisplay/Avatar.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="c-application c-avatar--container">
+	<div class="c-application c-avatar--container" :class="[computedSize]">
 		<i class="c-avatar" :class="[computedType, computedSize]" :style="computedStyle" />
 		<div class="c-avatar--item">
 			<Icon v-if="isProfileType" :name="computedIconName" />
@@ -122,23 +122,6 @@ export default {
 		position: relative;
 	}
 
-	// 사이즈
-	&.small {
-		width: 40px;
-		height: 40px;
-		line-height: 40px;
-	}
-	&.medium {
-		width: 48px;
-		height: 48px;
-		line-height: 48px;
-	}
-	&.large {
-		width: 68px;
-		height: 68px;
-		line-height: 68px;
-	}
-
 	// 타입
 	&.profile {
 		background: $gray100;
@@ -174,5 +157,22 @@ export default {
 			height: 40px;
 		}
 	}
+}
+
+// 사이즈
+.small {
+	width: 40px;
+	height: 40px;
+	line-height: 40px;
+}
+.medium {
+	width: 48px;
+	height: 48px;
+	line-height: 48px;
+}
+.large {
+	width: 68px;
+	height: 68px;
+	line-height: 68px;
 }
 </style>


### PR DESCRIPTION
<img width="371" alt="스크린샷 2021-07-27 오후 2 12 30" src="https://user-images.githubusercontent.com/19399338/127101698-1d71751d-2c8e-46a4-ae59-2382f09e798f.png">
flex를 사용하면 아바타가 탈출하는 오류가 있어서 수정합니다.
