### PR TITLE
[fix] CoreCard 답변 더보기 버튼 노출 조건 수정, overline v-html로 변경

### DIFF
--- a/src/Components/DataDisplay/Card/CoreCard.vue
+++ b/src/Components/DataDisplay/Card/CoreCard.vue
@@ -60,17 +60,20 @@ export default {
 		},
 		repliesCount: {
 			type: Number,
+			default: 0,
 		},
 		hiddenRepliesCount: {
 			type: Number,
+			default: 0,
 		},
 		likeCount: {
 			type: Number,
+			default: 0,
 		},
 	},
 	computed: {
 		isShowHiddenRepliesCount() {
-			return this.hiddenRepliesCount && this.hiddenRepliesCount > 0;
+			return this.hiddenRepliesCount > 0;
 		},
 	},
 	components: {

--- a/src/Components/DataDisplay/Card/CoreCard.vue
+++ b/src/Components/DataDisplay/Card/CoreCard.vue
@@ -25,8 +25,8 @@
 				<div class="c-card--replies-wrapper">
 					<slot name="replies" />
 
-					<NarrowButton v-if="isShowHiddenRepliesCount" color="blue400" size="medium">
-						+ {{ hiddenRepliesCount }}개 답변 더보기
+					<NarrowButton color="blue400" size="medium">
+						+ <template v-if="isShowHiddenRepliesCount">{{ hiddenRepliesCount }}개 답변 </template>더보기
 					</NarrowButton>
 				</div>
 			</template>

--- a/src/Components/DataDisplay/Card/CoreCard.vue
+++ b/src/Components/DataDisplay/Card/CoreCard.vue
@@ -2,7 +2,10 @@
 	<article class="c-application c-core-card">
 		<Box :paddings="[18, 20, 16, 20]" :has-border="!isMobile" border-color="gray200">
 			<div class="c-core-card--content-wrapper">
-				<Content type="overline"> {{ overlineLeft }}· {{ overlineRight }} </Content>
+				<Content type="overline">
+					<Typography element="span" v-html="overlineLeft" />
+					· <Typography element="span" v-html="overlineRight" />
+				</Content>
 				<Content type="title" v-html="title" />
 				<Content type="body" v-html="body" />
 				<RatingGroup>
@@ -38,6 +41,7 @@ import NarrowButton from '@/src/Components/Button/NarrowButton';
 import Content from '@/src/Components/DataDisplay/Content/Content';
 import RatingGroup from '@/src/Components/DataEntry/Rating/RatingGroup';
 import Rating from '@/src/Components/DataEntry/Rating/Rating';
+import Typography from '@/src/Elements/Core/Typography/Typography';
 
 export default {
 	name: 'CoreCard',
@@ -76,6 +80,7 @@ export default {
 		Divider,
 		Box,
 		Content,
+		Typography,
 	},
 };
 </script>

--- a/src/Components/DataDisplay/Card/CoreCard.vue
+++ b/src/Components/DataDisplay/Card/CoreCard.vue
@@ -22,7 +22,7 @@
 				<div class="c-card--replies-wrapper">
 					<slot name="replies" />
 
-					<NarrowButton v-if="hiddenRepliesCount" color="blue400" size="medium">
+					<NarrowButton v-if="isShowHiddenRepliesCount" color="blue400" size="medium">
 						+ {{ hiddenRepliesCount }}개 답변 더보기
 					</NarrowButton>
 				</div>
@@ -62,6 +62,11 @@ export default {
 		},
 		likeCount: {
 			type: Number,
+		},
+	},
+	computed: {
+		isShowHiddenRepliesCount() {
+			return this.hiddenRepliesCount && this.hiddenRepliesCount > 0;
 		},
 	},
 	components: {


### PR DESCRIPTION
1. 답변 더보기 버튼은 답변이 3개 이상이면 `+ n개 답변 더보기`, 아니면 `+ 더보기`로 노출됩니다.
2. overline에 검색 highlight 함수를 넣어줘야해서 v-html로 변경했습니다.