### PR TITLE
[change] cleanup-styles-on-destroy false

### DIFF
--- a/src/Components/DataDisplay/Swiper.vue
+++ b/src/Components/DataDisplay/Swiper.vue
@@ -4,7 +4,14 @@
 		@mouseenter="handleSwiperAutoplay('stop')"
 		@mouseleave="handleSwiperAutoplay('start')"
 	>
-		<base-swiper ref="mySwiper" class="swiper" :options="swiperOptions" v-bind="$attrs" v-on="$listeners">
+		<base-swiper
+			ref="mySwiper"
+			class="swiper"
+			:options="swiperOptions"
+			:cleanup-styles-on-destroy="false"
+			v-bind="$attrs"
+			v-on="$listeners"
+		>
 			<base-swiper-slide
 				v-for="(node, index) in Object.keys(this.$slots).length"
 				:key="`tabs-item-${index}-${key}`"


### PR DESCRIPTION
이 옵션이 있으면 component가 destroy될 때 inline style을 날려버림.
### 기존
![image](https://user-images.githubusercontent.com/32301380/130016882-26fa55b4-1892-494d-81ce-a3da758bc563.png)
### 네비게이션 시
![image](https://user-images.githubusercontent.com/32301380/130016860-2ffddecd-acf5-416a-bf02-9144e8c0d5bb.png)
