### PR TITLE
[change] Tabs hover하면 pc에서만 배경색 바꾸기

### DIFF
--- a/src/Components/DataDisplay/Tabs.vue
+++ b/src/Components/DataDisplay/Tabs.vue
@@ -176,8 +176,10 @@ export default {
 			@include flexbox();
 			position: relative;
 			@include align-items(center);
-			&:hover {
-				background-color: $gray100;
+			@include pc {
+				&:hover {
+					background-color: $gray100;
+				}
 			}
 			&::v-deep .c-button {
 				background: none !important;


### PR DESCRIPTION
모바일은 hover가 불가능한데, 배경색이 계속 회색으로 남아있어서 pc에서만 실행되도록 변경함