### PR TITLE
[fix] box-shadow safari에서 깨지는 오류 수정

### DIFF
--- a/assets/style/base/mixins.scss
+++ b/assets/style/base/mixins.scss
@@ -90,7 +90,10 @@
 
 // 툴팁 등에 사용
 @mixin shadow1 {
-  box-shadow: 0 0 6px rgba(0, 0, 0, 0.1);
+  @include ie10plus {
+    box-shadow: 0 0 6px rgba(0, 0, 0, 0.1);
+  }
+  filter: drop-shadow(0 0 6px rgba(0, 0, 0, 0.1));
 }
 // 모바일 카드를 감싼 box 등에 사용
 @mixin shadow2 {
@@ -98,11 +101,17 @@
 }
 // topbar, header 등에 사용
 @mixin shadow3 {
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+  @include ie10plus {
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+  }
+  filter: drop-shadow(0 2px 10px rgba(0, 0, 0, 0.05));
 }
 // xlarge 버튼 등에 사용
 @mixin shadow4 {
-  box-shadow: 0 3px 7px rgba(0, 0, 0, 0.06);
+  @include ie10plus {
+    box-shadow: 0 0 6px rgba(0, 0, 0, 0.1);
+  }
+  filter: drop-shadow(0 3px 7px rgba(0, 0, 0, 0.06));
 }
 
 @mixin transition($transition) {
@@ -300,5 +309,12 @@
         }
       }
     }
+  }
+}
+
+@mixin ie10plus() {
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    /* IE10+ CSS styles go here */
+    @content
   }
 }


### PR DESCRIPTION
## 이슈
safari에서 swiper 버튼 box-shadow가 짤리는 현상
<img width="76" alt="스크린샷 2021-08-20 오후 12 16 39" src="https://user-images.githubusercontent.com/19399338/130173735-4f509520-4aba-4cc9-8be0-1b64344ceb78.png">

## 해결
- `filter: drop-shadow`로 바꾸고 ie10+일 때는 기존처럼 `box-shadow` 사용
⚠️ shadow2는 spread-radius를 drop-shadow에서 지원하지 않아서 일단 두었음ㅠ_ㅠ
`box-shadow: 0 5px 10px 1px rgba(0, 0, 0, 0.03);` -> 1px 부분이 spread-radius
 → 참고로 현재 shadow2를 사용중인 TellingAvatarQuote는 safari에서 잘 나오고 있음