### PR TITLE
[fix] userInformation style

### DIFF
--- a/src/Components/DataDisplay/Content/UserInformation.vue
+++ b/src/Components/DataDisplay/Content/UserInformation.vue
@@ -98,7 +98,7 @@ export default {
 			}
 			.company {
 				@include ellipsis(1);
-				margin-right: 12px;
+				margin-right: 14px;
 			}
 		}
 		.information-wrapper {


### PR DESCRIPTION
icon 왼쪽 여백이 2px 생기면서 스타일 변경이 누락되어 추가했습니다.
<img width="204" alt="스크린샷 2021-09-08 오후 2 08 04" src="https://user-images.githubusercontent.com/19399338/132449810-1f47051d-13eb-4cdc-8735-59be41563040.png">
