### PR TITLE
[fix] date picker append-to-body false

### DIFF
--- a/src/Components/DataEntry/DatePicker.vue
+++ b/src/Components/DataEntry/DatePicker.vue
@@ -14,7 +14,7 @@
 			:editable="false"
 			:clearable="clearable"
 			:popup-class="`c-calendar-${uid}`"
-			:append-to-body="false"
+			:append-to-body="appendToBody"
 			:open.sync="open"
 			v-on="$listeners"
 			@change="handleChange"
@@ -78,6 +78,10 @@ export default {
 			default: null,
 		},
 		clearable: {
+			type: Boolean,
+			default: true,
+		},
+		appendToBody: {
 			type: Boolean,
 			default: true,
 		},

--- a/src/Components/DataEntry/DatePicker.vue
+++ b/src/Components/DataEntry/DatePicker.vue
@@ -14,6 +14,7 @@
 			:editable="false"
 			:clearable="clearable"
 			:popup-class="`c-calendar-${uid}`"
+			:append-to-body="false"
 			:open.sync="open"
 			v-on="$listeners"
 			@change="handleChange"


### PR DESCRIPTION
기존 date picker에서 
append-to-body 가 true로 기본 설정되어있는데,
이렇게 되면 date picker 의 팝업이 떳을 때
nuxt의 외부에 해당 팝업 엘리먼트가 생성됩니다..
![image](https://user-images.githubusercontent.com/46276533/132470459-e871e769-9f85-42a9-9f78-e50307ad6f5c.png)
따라서 style을 줄 수 없는 이슈가 있어서 false로 수정합니다..
(동훈님이 알려줌)