### PR TITLE
[fix] Typography font-size, line-height math 함수 활용하는 mixin으로 변경

### DIFF
--- a/src/Elements/Core/Typography/Typography.vue
+++ b/src/Elements/Core/Typography/Typography.vue
@@ -123,59 +123,55 @@ p {
 	word-break: keep-all;
 	word-wrap: break-word;
 }
+
+@mixin trans-font-size($size, $line, $math: round) {
+	font-size: $size;
+	line-height: $math($size * $line);
+}
+
 .c_display1 {
-	font-size: 42px;
-	line-height: 120%;
+	@include trans-font-size(42px, 1.2);
 	font-weight: bold;
 }
 .c_headline1 {
-	font-size: 32px;
-	line-height: 125%;
+	@include trans-font-size(32px, 1.25);
 	font-weight: bold;
 }
 .c_headline2 {
-	font-size: 28px;
-	line-height: 130%;
+	@include trans-font-size(28px, 1.3);
 	font-weight: bold;
 }
 .c_headline3 {
-	font-size: 26px;
-	line-height: 130%;
+	@include trans-font-size(26px, 1.3);
 	font-weight: bold;
 }
 .c_headline4 {
-	font-size: 24px;
-	line-height: 125%;
+	@include trans-font-size(24px, 1.25);
 	font-weight: bold;
 }
 .c_headline5 {
-	font-size: 22px;
-	line-height: 130%;
+	@include trans-font-size(22px, 1.3);
 	font-weight: normal;
 }
 .c_headline6 {
-	font-size: 18px;
-	line-height: 135%;
+	@include trans-font-size(18px, 1.35);
 	font-weight: bold;
 }
 .c_body1 {
-	font-size: 16px;
-	line-height: 150%;
+	@include trans-font-size(16px, 1.5);
 	font-weight: normal;
 }
 .c_body2 {
-	font-size: 14px;
-	line-height: 145%;
+	@include trans-font-size(14px, 1.45);
 	font-weight: normal;
 }
+
 .c_caption1 {
-	font-size: 12px;
-	line-height: 115%;
+	@include trans-font-size(12px, 1.15);
 	font-weight: 300;
 }
 .c_caption2 {
-	font-size: 10px;
-	line-height: 115%;
+	@include trans-font-size(10px, 1.15, floor);
 	font-weight: 300;
 }
 </style>


### PR DESCRIPTION
## 이슈
디자인상으로는 caption1 line-height가 14px인데 13.8로 계산되어 13px로 나오고 있습니다.
<img width="545" alt="스크린샷 2021-09-13 오후 4 07 46" src="https://user-images.githubusercontent.com/19399338/133038986-2513f6e7-ab5c-422b-8ce4-c2c471868b10.png">

## 개선
line-height가 소수일 경우, 내림되는 현상이 있어서 math함수를 활용하는 mixin으로 변경했습니다.