### PR TITLE
[fix] 아바타 id prop 추가 및 color와 연동

### DIFF
--- a/src/Components/DataDisplay/Avatar.vue
+++ b/src/Components/DataDisplay/Avatar.vue
@@ -18,6 +18,7 @@ import uniqueId from '@/utils/unique-id';
 
 export const avatarSizes = ['xsmall', 'small', 'medium', 'large'];
 export const avatarTypes = ['text', 'profile', 'logo', 'image'];
+const avatarColors = ['#f5b3b6', '#f4c19f', '#efd76f', '#b0d0f5', '#b8bdea', '#b3e2de'];
 
 export default {
 	name: 'Avatar',
@@ -44,6 +45,10 @@ export default {
 		src: {
 			type: String,
 			default: null,
+		},
+		id: {
+			type: Number,
+			default: -1,
 		},
 	},
 	data() {
@@ -79,10 +84,12 @@ export default {
 			}
 			return {};
 		},
+		computedId() {
+			return this.id > -1 ? this.id : this.uid;
+		},
 		computedRandomBackground() {
-			const colors = ['#f5b3b6', '#f4c19f', '#efd76f', '#b0d0f5', '#b8bdea', '#b3e2de'];
-			const randomNo = this.uid % 5;
-			return colors[randomNo];
+			const randomNo = this.computedId % avatarColors.length;
+			return avatarColors[randomNo];
 		},
 		computedRandomText() {
 			const text = 'ABCDEGHIJKLMNOPQRSTUVWXYZ';

--- a/stories/DataDisplay/Avatar.stories.mdx
+++ b/stories/DataDisplay/Avatar.stories.mdx
@@ -35,6 +35,12 @@ import Avatar, { avatarSizes, avatarTypes } from '@/src/Components/DataDisplay/A
                 type: "text",
             },
         },
+        id: {
+            description: "아이디",
+            control: {
+                type: "number",
+            },
+        },
     }}
 />
 


### PR DESCRIPTION
아바타가 유저별로 고유한 색상을 가져야하는 경우가 생겨서 id값을 받아 컬러를 설정하는 작업을 추가했습니다.