### PR TITLE
Logo color 제한 해제, 예시 추가

### DIFF
--- a/src/Elements/Core/Logo/Logo.vue
+++ b/src/Elements/Core/Logo/Logo.vue
@@ -10,7 +10,7 @@
 
 <script>
 import LogoComentoHorizontal from '@/assets/images/logo/logo-comento-horizontal.svg?inline';
-import { colors, colorKeys } from '@/src/Elements/Core/Colors';
+import { colors } from '@/src/Elements/Core/Colors';
 
 export default {
 	name: 'Logo',
@@ -34,22 +34,14 @@ export default {
 		color: {
 			type: String,
 			default: 'primary',
-			validator(value) {
-				const isValid = colorKeys.indexOf(value) !== -1;
-				if (!isValid) {
-					console.error(`${value} is not a valid name of the icon color`);
-				}
-				return isValid;
-			},
 		},
 	},
 	computed: {
 		computedColor() {
-			if (this.color) {
-				return { fill: colors[this.color] };
-			} else {
+			if (!this.color) {
 				return null;
 			}
+			return { fill: colors[this.color] ?? this.color };
 		},
 	},
 	components: {

--- a/stories/Logo/Logo.stories.mdx
+++ b/stories/Logo/Logo.stories.mdx
@@ -1,6 +1,5 @@
 import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import Logo from "@/src/Elements/Core/Logo/Logo";
-import { colorKeys } from "@/src/Elements/Core/Colors";
 
 <Meta
   title="Core/Logo"
@@ -37,8 +36,7 @@ import { colorKeys } from "@/src/Elements/Core/Colors";
         },
       },
       control: {
-        type: "select",
-        options: colorKeys,
+        type: "text",
       },
     },
   }}
@@ -68,7 +66,11 @@ export const Default = (args, { argTypes }) => ({
         {{
             template: `
                 <div>
-                  <Logo  />
+                  <Logo color="primary" class="p-14" />
+                  <Logo color="#353535" class="p-14"  />
+                  <div style="background: rgba(18, 109, 93, 0.7);" class="d-inline-block p-14">
+                    <Logo color="white"  />
+                  </div>
                 </div>
         `,
             components: { Logo },


### PR DESCRIPTION
<img width="188" alt="스크린샷 2021-09-30 오후 2 43 40" src="https://user-images.githubusercontent.com/19399338/135394390-72cbd83f-7de6-4aa3-80fb-a190c2ea1f7e.png">

- Logo color가 디자인 시스템 색상이 아니어도 사용할 수 있도록 제한을 없앴습니다.
- 스토리 예시를 추가했습니다.