### PR TITLE
[fix] ios 15.0 이상 safari 스와이퍼 플리커링 이슈 대응

### DIFF
--- a/src/Components/DataDisplay/Swiper.vue
+++ b/src/Components/DataDisplay/Swiper.vue
@@ -257,6 +257,14 @@ export default {
 					},
 				}),
 				slidesPerGroup: this.slidesPerGroup,
+				on: {
+					// ios 15.0 이상 safari에서 resizeHandler로 인한 플리커링 버그 대응
+					imagesReady: () => {
+						if (this.$refs.mySwiper.$swiper.device.ios) {
+							window.removeEventListener('resize', this.$refs.mySwiper.$swiper.resize.resizeHandler);
+						}
+					},
+				},
 			};
 		},
 		computedIndicatorColorClass() {


### PR DESCRIPTION
원인: safari 하단 주소창일 경우 스와이핑 시 resize 이벤트가 실행되면서
해당 이벤트를 listen 하고 있던 swiper가 껌뻑였던 것

해결: ios일 경우 resize 이벤트 리스너를 제거