### PR TITLE
fix: ios 15.0 대응 코드 삭제

### DIFF
--- a/src/components/components/dataDisplay/Swiper.vue
+++ b/src/components/components/dataDisplay/Swiper.vue
@@ -257,14 +257,6 @@ export default {
 					},
 				}),
 				slidesPerGroup: this.slidesPerGroup,
-				on: {
-					// ios 15.0 이상 safari에서 resizeHandler로 인한 플리커링 버그 대응
-					imagesReady: () => {
-						if (this.$refs.mySwiper.$swiper.device.ios) {
-							window.removeEventListener('resize', this.$refs.mySwiper.$swiper.resize.resizeHandler);
-						}
-					},
-				},
 			};
 		},
 		computedIndicatorColorClass() {


### PR DESCRIPTION
iOS 15.1에서 해당 문제를 해결했고,
device가 없는 경우 swiper 가 동작하지 않는 문제가 생겨 삭제합니다.