### PR TITLE
fix: Badge inline type style 오류 수정

### DIFF
--- a/src/components/components/dataDisplay/Badge.vue
+++ b/src/components/components/dataDisplay/Badge.vue
@@ -166,12 +166,8 @@ export default {
 
 	&--container {
 		&.inline {
-			display: flex;
-			.c-badge {
-				display: block;
-				&--wrapper {
-					position: static;
-				}
+			.c-badge--wrapper {
+				position: static;
 			}
 		}
 		&.absolute {


### PR DESCRIPTION
Tabs 스토리북 예시에서 Badge inline type 스타일 오류를 발견해서 수정했습니다.

![스크린샷 2021-11-08 오후 12 01 57](https://user-images.githubusercontent.com/19399338/140677710-e4e96139-4b0c-4910-9fb8-0a8be7bf0755.png)
![스크린샷 2021-11-08 오후 12 03 33](https://user-images.githubusercontent.com/19399338/140677782-46947446-1074-49ad-be1b-58539dfbe7d1.png)