### PR TITLE
[change] tooltip 내부 wrapper border-radius 추가

### DIFF
--- a/src/assets/style/tooltip/tooltip.scss
+++ b/src/assets/style/tooltip/tooltip.scss
@@ -1,12 +1,13 @@
-@import "common";
+@import 'common';
 .c-tooltip {
-  .c-tooltip--inner {
-    padding: 0 !important;
-    .c-tooltip--content-wrapper {
-      padding: 8px 12px;
-      a {
-        display: inline-block;
-      }
-    }
-  }
+	.c-tooltip--inner {
+		padding: 0 !important;
+		.c-tooltip--content-wrapper {
+			padding: 8px 12px;
+			border-radius: 4px;
+			a {
+				display: inline-block;
+			}
+		}
+	}
 }


### PR DESCRIPTION
c-tooltip--content-wrapper에 background가 생기면 외부 border-radius를 덮어버리는 문제가 있어 추가