### PR TITLE
fix: 파일 이름이 길 때 말줄임표 추가

### DIFF
--- a/src/components/components/dataDisplay/list/fileList/FileItem.vue
+++ b/src/components/components/dataDisplay/list/fileList/FileItem.vue
@@ -1,7 +1,7 @@
 <template>
 	<ListItem class="c-application c-file-item--container" @click="handleClickFileItem({ file, index })">
 		<div class="c-file-item--content" @click="handleClickFileItemContent({ file, index })">
-			<Typography type="caption1" color="gray700">{{ file.title || file.name }}</Typography>
+			<Typography type="caption1" color="gray700" class="text-truncate">{{ file.title || file.name }}</Typography>
 		</div>
 		<Icon
 			v-if="isEdit"
@@ -79,6 +79,7 @@ export default {
 			cursor: pointer;
 			@include flexbox();
 			@include align-items(center);
+			overflow: hidden;
 		}
 	}
 }


### PR DESCRIPTION
파일 이름이 길면 삭제 버튼이 보이지 않음