### PR TITLE
feat: IconButton 추가

### DIFF
--- a/src/components/components/general/button/IconButton.vue
+++ b/src/components/components/general/button/IconButton.vue
@@ -25,6 +25,7 @@ export default {
 	props: {
 		iconName: {
 			type: String,
+			required: true,
 		},
 		/**
 		 * 크기(small, medium, large, xlarge)

--- a/src/components/components/general/button/IconButton.vue
+++ b/src/components/components/general/button/IconButton.vue
@@ -17,6 +17,9 @@ import { buttonColors } from '@/components/components/general/button/Button';
 import Icon from '@/components/elements/core/icon/Icon';
 export const IconButtonSizes = ['small', 'medium', 'large'];
 
+/**
+ * @displayName c-icon-button
+ */
 export default {
 	name: 'IconButton',
 	props: {

--- a/src/components/components/general/button/IconButton.vue
+++ b/src/components/components/general/button/IconButton.vue
@@ -1,0 +1,114 @@
+<template>
+	<button
+		class="c-application c-icon-button"
+		:class="[computedSize]"
+		v-bind="$attrs"
+		:disabled="disabled"
+		v-on="$listeners"
+		@click="$event.target.blur()"
+	>
+		<Icon :name="iconName" :color="computedColor" />
+	</button>
+</template>
+
+<script>
+import { buttonColors } from '@/components/components/general/button/Button';
+
+import Icon from '@/components/elements/core/icon/Icon';
+export const IconButtonSizes = ['small', 'medium', 'large'];
+
+export default {
+	name: 'IconButton',
+	props: {
+		iconName: {
+			type: String,
+		},
+		/**
+		 * 크기(small, medium, large, xlarge)
+		 */
+		size: {
+			type: String,
+			default: 'medium',
+			validator(value) {
+				return IconButtonSizes.includes(value);
+			},
+		},
+		color: {
+			type: String,
+			default: 'primary',
+			validator(value) {
+				return buttonColors.includes(value);
+			},
+		},
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	computed: {
+		computedSize() {
+			return this.size;
+		},
+		computedColor() {
+			return this.disabled ? 'gray200' : this.color;
+		},
+	},
+	components: {
+		Icon,
+	},
+};
+</script>
+
+<style lang="scss" scoped>
+.c-icon-button {
+	background-color: transparent;
+	border: none;
+	cursor: pointer;
+	@include border-radius(4px);
+	@include flexbox();
+	@include align-items(center);
+	@include justify-content(center);
+
+	> .c-icon {
+		cursor: inherit;
+	}
+
+	@include mobile {
+		@include remove-active-and-focus();
+	}
+
+	&:hover,
+	&:focus,
+	&:active,
+	&.hover-test {
+		background-color: $gray100;
+	}
+
+	&:disabled {
+		cursor: not-allowed !important;
+		background: none;
+		&:active {
+			pointer-events: none;
+		}
+		.c-button--icon::v-deep .c-icon {
+			@include disabled();
+		}
+	}
+
+	&.small {
+		height: 20px;
+		width: 20px;
+		padding: 2px;
+	}
+	&.medium {
+		width: 28px;
+		height: 28px;
+		padding: 2px;
+	}
+	&.large {
+		width: 32px;
+		height: 32px;
+		padding: 2px;
+	}
+}
+</style>

--- a/stories/components/general/button/Button.stories.mdx
+++ b/stories/components/general/button/Button.stories.mdx
@@ -3,6 +3,7 @@ import Button, { buttonSizes, buttonColors, buttonTypes } from '@/components/com
 import Typography from '@/components/elements/core/typography/Typography';
 import Icon from '@/components/elements/core/icon/Icon';
 import Loader from '@/components/components/other/Loader';
+import IconButton from "@/components/components/general/button/IconButton";
 
 <Meta
   title="General/Button/Button"
@@ -321,6 +322,49 @@ export const Default = (args, { argTypes }) => ({
                 </div>
         `,
             components: { Button, Icon },
+        }}
+    </Story>
+</Canvas>
+
+### IconButton Sizes
+<Canvas>
+    <Story name="IconButtonSizes" height="100px">
+        {{
+            template: `
+                <div>
+                      <template v-for="(item, index) in exampleData">
+                        <div class="flex mb-10">
+                            <IconButton :icon-name="item.iconName" :size="item.iconSize" class="mr-10"/>
+                            <IconButton :icon-name="item.iconName" :size="item.iconSize" class="hover-test mr-10"/>
+                            <IconButton :icon-name="item.iconName" :size="item.iconSize" disabled class="mr-10"/>
+                        </div>
+                      </template>
+                </div>
+            `,
+            data() {
+                return {
+                    exampleData: [
+                        {
+                            iconName: 'IconBookmarkMediumFill',
+                            iconSize: 'small'
+                        },
+                        {
+                            iconName:  'IconSendLargeFill',
+                            iconSize: 'medium',
+                        },
+                        {
+                            iconName:  'IconStarXLargeLine',
+                            iconSize: 'large'
+                        },
+                    ]
+                }
+            },
+            components: { IconButton,
+                'ButtonStateTitle': {
+                    template: `<Typography type="body2" color="gray400" class="mb-10" style="min-width: 70px"><slot/></Typography>`,
+                    components: {Typography},
+                },
+            },
         }}
     </Story>
 </Canvas>

--- a/stories/components/general/button/Button.stories.mdx
+++ b/stories/components/general/button/Button.stories.mdx
@@ -3,7 +3,6 @@ import Button, { buttonSizes, buttonColors, buttonTypes } from '@/components/com
 import Typography from '@/components/elements/core/typography/Typography';
 import Icon from '@/components/elements/core/icon/Icon';
 import Loader from '@/components/components/other/Loader';
-import IconButton from "@/components/components/general/button/IconButton";
 
 <Meta
   title="General/Button/Button"
@@ -322,49 +321,6 @@ export const Default = (args, { argTypes }) => ({
                 </div>
         `,
             components: { Button, Icon },
-        }}
-    </Story>
-</Canvas>
-
-### IconButton Sizes
-<Canvas>
-    <Story name="IconButtonSizes" height="100px">
-        {{
-            template: `
-                <div>
-                      <template v-for="(item, index) in exampleData">
-                        <div class="flex mb-10">
-                            <IconButton :icon-name="item.iconName" :size="item.iconSize" class="mr-10"/>
-                            <IconButton :icon-name="item.iconName" :size="item.iconSize" class="hover-test mr-10"/>
-                            <IconButton :icon-name="item.iconName" :size="item.iconSize" disabled class="mr-10"/>
-                        </div>
-                      </template>
-                </div>
-            `,
-            data() {
-                return {
-                    exampleData: [
-                        {
-                            iconName: 'IconBookmarkMediumFill',
-                            iconSize: 'small'
-                        },
-                        {
-                            iconName:  'IconSendLargeFill',
-                            iconSize: 'medium',
-                        },
-                        {
-                            iconName:  'IconStarXLargeLine',
-                            iconSize: 'large'
-                        },
-                    ]
-                }
-            },
-            components: { IconButton,
-                'ButtonStateTitle': {
-                    template: `<Typography type="body2" color="gray400" class="mb-10" style="min-width: 70px"><slot/></Typography>`,
-                    components: {Typography},
-                },
-            },
         }}
     </Story>
 </Canvas>

--- a/stories/components/general/button/IconButton.stories.mdx
+++ b/stories/components/general/button/IconButton.stories.mdx
@@ -1,0 +1,103 @@
+import { ArgsTable, Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { buttonSizes, buttonColors, buttonTypes } from '@/components/components/general/button/Button';
+import Typography from '@/components/elements/core/typography/Typography';
+import IconButton, { IconButtonSizes } from "@/components/components/general/button/IconButton";
+import { IconNames } from "@/components/elements/core/icon/Icon";
+
+<Meta
+    title="General/Button/IconButton"
+    component={ IconButton }
+    argTypes={{
+        iconName: {
+            description: "버튼에 들어갈 텍스트",
+            defaultValue: "iconSendLargeFill",
+            control: {
+                type: "select",
+                options: IconNames
+            },
+        },
+        size: {
+            description: "버튼의 크기",
+            control: {
+                type: "select",
+                options: IconButtonSizes,
+            },
+        },
+        color: {
+            description: "버튼의 색상 타입",
+            control: {
+                type: "select",
+                options: buttonColors,
+            },
+        },
+        disabled: {
+            description: "버튼의 disabled 상태",
+        },
+    }}
+/>
+
+export const Default = (args, { argTypes }) => ({
+    props: Object.keys(argTypes),
+    components: { IconButton },
+    template:
+        `<IconButton
+            :iconName="iconName"
+            :size="size"
+            :color="color"
+            :disabled="disabled"
+        />`,
+});
+
+# Button
+
+**Button** 컴포넌트의 문서입니다.
+
+<Story name="Default" height="100px">
+    {Default.bind({})}
+</Story>
+
+<ArgsTable story="Default" />
+
+## Stories
+### All
+<Canvas>
+    <Story name="All" height="100px">
+        {{
+            template: `
+                <div>
+                      <template v-for="(item, index) in exampleData">
+                        <div class="flex mb-10">
+                            <IconButton :icon-name="item.iconName" :size="item.iconSize" class="mr-10"/>
+                            <IconButton :icon-name="item.iconName" :size="item.iconSize" class="hover-test mr-10"/>
+                            <IconButton :icon-name="item.iconName" :size="item.iconSize" disabled class="mr-10"/>
+                        </div>
+                      </template>
+                </div>
+            `,
+            data() {
+                return {
+                    exampleData: [
+                        {
+                            iconName: 'IconBookmarkMediumFill',
+                            iconSize: 'small'
+                        },
+                        {
+                            iconName:  'IconSendLargeFill',
+                            iconSize: 'medium',
+                        },
+                        {
+                            iconName:  'IconStarXLargeLine',
+                            iconSize: 'large'
+                        },
+                    ]
+                }
+            },
+            components: { IconButton,
+                'ButtonStateTitle': {
+                    template: `<Typography type="body2" color="gray400" class="mb-10" style="min-width: 70px"><slot/></Typography>`,
+                    components: {Typography},
+                },
+            },
+        }}
+    </Story>
+</Canvas>


### PR DESCRIPTION
IconButton은 컴포넌트를 따로 분리했습니다.
Button안에 들어가면 너무 지저분하고 불필요한게 많은 것 같다는 판단입니다.
소중한 피드백은 감사합니다.
Figma Component Button에 type Icon 보시면 됩니다.
Story는 Button Story에 합쳤습니다.

https://www.figma.com/file/cHjLshiQwSZSjZ79aJWZJk/%5B%EC%9E%91%EC%97%85%EC%A4%91%5D-NEW-design-system?node-id=111%3A7299