### PR TITLE
fix: TextField disabled일 때 append 영역은 style 반영 안 되는 오류 수정

### DIFF
--- a/src/components/components/dataEntry/input/TextField.vue
+++ b/src/components/components/dataEntry/input/TextField.vue
@@ -224,6 +224,7 @@ export default {
 <style lang="scss" scoped>
 $outlined-padding: 16px;
 $underlined-padding: 4px;
+$disabled-background-color: $gray000;
 
 .c-text-field {
 	position: relative;
@@ -242,7 +243,17 @@ $underlined-padding: 4px;
 			color: $gray300;
 		}
 		&:disabled {
-			background: $gray000;
+			cursor: not-allowed !important;
+			background: $disabled-background-color;
+
+			&:active {
+				pointer-events: none;
+			}
+
+			~ .c-text-field--append {
+				cursor: not-allowed !important;
+				background: $disabled-background-color;
+			}
 		}
 
 		&-wrapper {
@@ -321,12 +332,7 @@ $underlined-padding: 4px;
 				padding-right: $underlined-padding;
 			}
 		}
-		&:disabled {
-			cursor: not-allowed !important;
-			&:active {
-				pointer-events: none;
-			}
-		}
+
 		&[readonly],
 		&[readonly='readonly'] {
 			&:focus {


### PR DESCRIPTION
<img width="320" alt="스크린샷 2022-01-28 오후 3 22 00" src="https://user-images.githubusercontent.com/19399338/151497852-1c233ba0-1b81-403d-a733-99209174366e.png">
append영역에는 disabled의 background, cursor가 반영되지 않아서 오류 수정