### PR TITLE
feat: avatar icon color prop 추가

### DIFF
--- a/src/components/components/dataDisplay/Avatar.vue
+++ b/src/components/components/dataDisplay/Avatar.vue
@@ -2,7 +2,7 @@
 	<div class="c-application c-avatar--container" :class="[computedSize]">
 		<i class="c-avatar" :class="[computedType, computedSize]" :style="computedStyle" />
 		<div class="c-avatar--item">
-			<Icon v-if="isProfileType" :name="computedIconName" />
+			<Icon v-if="isProfileType" :name="computedIconName" :color="computedColorName" />
 			<div v-if="isLogoType" class="c-avatar--logo" :class="[computedSize]" />
 			<Typography v-if="isTextType" :type="computedTypography" :font-weight="700" color="white">
 				{{ text || computedRandomText }}
@@ -60,6 +60,10 @@ export default {
 		id: {
 			type: Number,
 			default: -1,
+		},
+		color: {
+			type: String,
+			default: 'black',
 		},
 	},
 	data() {
@@ -125,6 +129,9 @@ export default {
 				large: '2XLarge',
 			};
 			return `IconProfile${iconBySize[this.size]}Fill`;
+		},
+		computedColorName() {
+			return this.color.toLowerCase();
 		},
 	},
 	components: {


### PR DESCRIPTION
avatar의 type이 profile일 경우 컬러를 변경 할 수 있도록 prop을 추가 하는 작업을 진행하였습니다.

고민 포인트
- 현재 laravel에서 사용하는 컬러 변수는 대문자를 이용한 hex code로 구성 되어 있습니다. ex) #2C2C2C
- 이를 그대로 사용 할 경우 컬러값을 읽어내지 못하는 경우가 생겨, toLowerCase로 변환해서 사용하였습니다.
- 임시적으로 해결하였지만 많아지면 꽤 번거로운 작업이 되지 않을까 생각합니다.

혹시 좋은 방법이 없을까요?