### PR TITLE
fix: swiper 요소가 모두 파싱 되고, init 되도록 변경

### DIFF
--- a/src/components/components/dataDisplay/Swiper.vue
+++ b/src/components/components/dataDisplay/Swiper.vue
@@ -255,6 +255,7 @@ export default {
 				this.slidesPerView === 'auto';
 			return {
 				loop: this.loop,
+				init: false,
 				navigation: {
 					nextEl: swiperButtonNextSelector,
 					prevEl: swiperButtonPrevSelector,
@@ -301,6 +302,12 @@ export default {
 				`swiper-button-background-circle swiper-button-background-circle-${this.controlsColor}`
 			);
 		},
+	},
+	mounted() {
+		// swiper 요소가 모두 파싱 되고 init 되도록
+		this.$nextTick(() => {
+			this.$refs.mySwiper.$swiper.init();
+		});
 	},
 	methods: {
 		handleSwiperAutoplay(type) {


### PR DESCRIPTION
swiper 옵션에서 loop가 true일때, 요소들의 옵션이 적용 되지 않는 이슈가 있어,

mounted에서 요소들이 모두 파싱 되는걸 기다린 다음, swiper가 init 되도록 변경 하였습니다.