### PR TITLE
feat: Banner 변경

### DIFF
--- a/src/components/components/message/Banner.vue
+++ b/src/components/components/message/Banner.vue
@@ -1,18 +1,10 @@
 <template>
-	<div class="c-application c-banner" :class="[computedType]">
-		<div class="c-banner--image">
-			<slot name="image" />
+	<div class="c-application c-banner" :class="[computedType]" :style="computedHeight">
+		<div class="c-banner--background" :class="[computedBlur]">
+			<slot name="background" />
 		</div>
-		<div class="c-banner--container">
-			<div class="c-banner--container-title">
-				<slot name="title" />
-			</div>
-			<div class="c-banner--container-description">
-				<slot name="description" />
-			</div>
-			<div class="c-banner--container-action">
-				<slot name="action" />
-			</div>
+		<div class="c-banner--content">
+			<slot />
 		</div>
 	</div>
 </template>
@@ -31,7 +23,7 @@ export default {
 		 */
 		type: {
 			type: String,
-			default: 'standard',
+			default: 'full',
 			validator(value) {
 				const isValid = bannerTypes.indexOf(value) !== -1;
 				if (!isValid) {
@@ -40,10 +32,25 @@ export default {
 				return isValid;
 			},
 		},
+		blur: {
+			type: Boolean,
+			default: false,
+		},
+		height: {
+			type: String,
+		},
 	},
 	computed: {
 		computedType() {
 			return this.type;
+		},
+		computedBlur() {
+			return this.blur ? 'blur' : '';
+		},
+		computedHeight() {
+			return {
+				'--height': this.height,
+			};
 		},
 	},
 };
@@ -52,29 +59,46 @@ export default {
 <style scoped lang="scss">
 .c-banner {
 	position: relative;
-	&.full {
-		max-width: 1920px;
-		width: 100%;
-	}
+	display: grid;
+	height: var(--height);
+
 	&.standard {
 		max-width: 1108px;
-		width: 100%;
-		@include border-radius(20px);
 		overflow: hidden;
+		@include border-radius(20px);
 	}
-	&--container {
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		@include transform(translate(-50%, -50%));
-		&-description {
-			margin-top: 8px;
+
+	&--content,
+	&--background {
+		grid-area: 1/-1;
+	}
+
+	&--background {
+		height: 100%;
+
+		& > * {
+			width: 100%;
+			max-height: 100%;
+			height: var(--height);
+			object-fit: cover;
 		}
-	}
-	&--image {
-		display: block;
-		vertical-align: top;
-		width: 100%;
+
+		&.blur {
+			position: relative;
+			backdrop-filter: blur(0);
+
+			&::before {
+				content: '';
+				position: absolute;
+				top: 0;
+				left: 0;
+				right: 0;
+				width: 100%;
+				height: 100%;
+				background: rgba(0, 0, 0, 0.25);
+				backdrop-filter: blur(30px);
+			}
+		}
 	}
 }
 </style>

--- a/stories/components/message/Banner.stories.mdx
+++ b/stories/components/message/Banner.stories.mdx
@@ -1,56 +1,54 @@
-import { ArgsTable, Meta, Story } from '@storybook/addon-docs/blocks';
+import { ArgsTable, Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import Banner from '@/components/components/message/Banner';
 import Button from '@/components/components/general/button/Button';
 import Typography from '@/components/elements/core/typography/Typography';
+import NewGrid from '@/components/layout/NewGrid';
+import NewRow from '@/components/layout/NewRow';
+import NewCol from '@/components/layout/NewCol';
 
 <Meta
-    title="Message/Banner"
-    component={ Banner }
-    argTypes={{
-        title: {
-            description: "Banner에 main 텍스트",
-            defaultValue: "Banner Title",
-            control: { type: "text" },
-        },
-        description: {
-            description: "Banner에 sub 텍스트",
-            defaultValue: "Banner description",
-            control: { type: "text" },
-        },
-        type: {
-            description: "banner 종류",
-            defaultValue: 'standard',
-            control: {
-                type: "select",
-                options: ["standard", "full"],
-            },
-        },
-    }}
+	title="Message/Banner"
+	component={Banner}
+	argTypes={{
+		type: {
+			description: 'banner 종류',
+			defaultValue: 'standard',
+			control: {
+				type: 'select',
+				options: ['standard', 'full'],
+			},
+		},
+		height: {
+			defaultValue: '280px',
+		},
+	}}
 />
 
 export const Default = (args, { argTypes }) => ({
-    props: Object.keys(argTypes),
-    components: { Button, Banner, Typography },
-    template: `
-        <div>
-            <Banner :type="type">
-                <template v-slot:image>
-                    <div style="background: lightgray; height: 250px;"></div>
+	props: Object.keys(argTypes),
+	components: { Button, Banner, Typography, NewGrid, NewRow, NewCol },
+	template: `<div>
+            <Banner :type="type" :blur="blur" :height="height">
+                <template v-slot:background>
+                    <div style="background-color: #f3f4f5;"></div>
                 </template>
-                <template v-slot:title>
-                    <Typography type="headline1" color="gray900" align="center">
-                        {{title}}
-                    </Typography>
-                </template>
-                <template v-slot:description>
-                    <Typography type="headline6" color="gray800" align="center">
-                        {{description}}
-                    </Typography>
-                </template>
-                <template v-slot:action>
+                <template v-slot>
+                    <NewGrid>
+                        <NewRow>
+                            <NewCol :col-sm="4" :col-lg="12">
+                                <Typography class="mt-80" type="headline1" color="gray800" align="left">
+                                    Title
+                                </Typography>
+                                <Typography type="headline6" color="gray800" align="left">
+                                    description
+                                </Typography>
+                                <Button class="mt-32 mb-40" full>CTA BTN</Button>
+                            </NewCol>
+                        </NewRow>
+                    </NewGrid>
                 </template>
             </Banner>
-        </div>`
+        </div>`,
 });
 
 # Banner
@@ -58,8 +56,42 @@ export const Default = (args, { argTypes }) => ({
 **Banner** 컴포넌트의 문서입니다.
 
 <Story name="Default" height="100px">
-    {Default.bind({})}
+	{Default.bind({})}
 </Story>
 
 <ArgsTable story="Default" />
 
+## Stories
+
+### All
+
+<Canvas>
+	<Story name="All" height="100px">
+		{{
+			components: { Banner, NewGrid, NewCol, NewRow, Typography, Button },
+			template: `
+                <div>
+                    <Banner type="standard" blur height="280px">
+                <template v-slot:background>
+                    <img src="https://cdn.comento.kr/edu/title_VaZDZCpmRI.jpg?s=960x502" />
+                </template>
+                <template v-slot>
+                    <NewGrid>
+                        <NewRow>
+                            <NewCol :col-sm="4" :col-lg="12">
+                                <Typography class="mt-80" type="headline1" color="gray000" align="left">
+                                    Title
+                                </Typography>
+                                <Typography type="headline6" color="gray000" align="left">
+                                    description
+                                </Typography>
+                                <Button class="mt-32 mb-40" size="xlarge">이동하기</Button>
+                            </NewCol>
+                        </NewRow>
+                    </NewGrid>
+                </template>
+            </Banner>
+            `,
+		}}
+	</Story>
+</Canvas>


### PR DESCRIPTION
<img width="902" alt="스크린샷 2022-03-02 오후 5 46 13" src="https://user-images.githubusercontent.com/45070463/156326902-d84ecbc2-2d21-4f6b-be1d-b93caeffb79c.png">

전혀 쓰고 있지 않은 컴포넌트여서 업무 중에 사용한 배너들처럼 만들 수 있게 만들고 예시를 스토리북에 추가했습니다