### PR TITLE
feat: Typography에서 linkify 제거

### DIFF
--- a/src/components/elements/core/typography/Typography.vue
+++ b/src/components/elements/core/typography/Typography.vue
@@ -1,7 +1,6 @@
 <template>
 	<component
 		:is="element"
-		v-linkify:options="{ className: 'linkified' }"
 		class="c-application c-typography"
 		:class="computedClass"
 		:style="computedStyle"
@@ -12,7 +11,6 @@
 </template>
 
 <script>
-import linkify from 'vue-linkify';
 import { colors } from '@/utils/constants/color';
 
 export const TypographyTypes = [
@@ -125,9 +123,6 @@ export default {
 		fontWeightClass() {
 			return this.fontWeight && !this.isNumberFontWeight ? `f-${this.fontWeight}` : '';
 		},
-	},
-	directives: {
-		linkify,
 	},
 };
 </script>


### PR DESCRIPTION
linkify때문에 vue click event가 작동하지 않음