### PR TITLE
Mixin 추가

### DIFF
--- a/src/assets/style/base/mixins.scss
+++ b/src/assets/style/base/mixins.scss
@@ -354,7 +354,7 @@
 @mixin image-rendering($value) {
   @if $value == crisp-edges {
     image-rendering: -moz-crisp-edges;
-    image-rendering:   -o-crisp-edges;
+    image-rendering: -o-crisp-edges;
     image-rendering: -webkit-optimize-contrast;
     image-rendering: crisp-edges;
   } @else {


### PR DESCRIPTION
1. landscape-mobile, landscape-pc 추가
VOD를 만들 때 스마트폰 가로모드를 고려할 필요가 있어서 기존의 screen-md 값을 활용한 landscape mixin을 새로 만들었습니다.

2. image-rendering 추가
FE팀미팅에서 이야기한 이미지가 흐릿해지는 문제를 보완하기 위해 image-rendering 믹스인을 만들었습니다. 전체 적용도 테스트해봤지만 텍스트가 포함된 이미지가 결과가 좋지 않아 믹스인을 만들어 문제가 되는 이미지에만 추가하는 방식으로 진행했습니다. crisp-edges가 표준 값인데 아직 브라우저마다 구현값이 달라서 crisp-edges를 사용할 때는 vendor-prefix를 모두 적용할 수 있게 만들었습니다.