### PR TITLE
본문이 길어질 경우 아이콘이 축소 되는 이슈

### DIFF
--- a/src/components/components/dataDisplay/list/fileList/FileItem.vue
+++ b/src/components/components/dataDisplay/list/fileList/FileItem.vue
@@ -11,6 +11,7 @@
 			v-if="isRemovable"
 			name="IconTrashMediumLine"
 			color="gray500"
+			style="flex-shrink: 0"
 			@click.stop="handleClickFileTrashIcon({ file, index })"
 		/>
 		<template v-else>
@@ -88,6 +89,7 @@ export default {
 			overflow: hidden;
 			&-icon {
 				cursor: pointer;
+				flex-shrink: 0;
 				margin-right: 4px;
 			}
 		}

--- a/src/components/components/message/Callout.vue
+++ b/src/components/components/message/Callout.vue
@@ -17,16 +17,15 @@
 					<Typography class="c-callout--message" color="gray700" :type="computedFontType">
 						<slot />
 					</Typography>
+					<!-- 닫기 -->
+					<Icon
+						v-if="closable"
+						class="c-callout--close-button c-pointer"
+						color="gray300"
+						:name="computedCloseIconName"
+						@click.stop.capture="handleClose"
+					/>
 				</div>
-
-				<!-- 닫기 -->
-				<Icon
-					v-if="closable"
-					class="c-callout--close-button c-pointer"
-					color="gray300"
-					:name="computedCloseIconName"
-					@click.stop.capture="handleClose"
-				/>
 			</div>
 		</div>
 	</transition>
@@ -230,6 +229,7 @@ export default {
 	}
 	&--close-button {
 		margin-left: 4px;
+		flex-shrink: 0;
 	}
 }
 


### PR DESCRIPTION
callout, fileInput등 본문과 아이콘이 함께 들어가는 컴포넌트에서 본문이 길어지면 양측에 있는 아이콘이 축소 되는 이슈가 발생 되었습니다.
