### PR TITLE
fix: medium ListItem 상하 패딩 수정

### DIFF
--- a/src/components/components/dataDisplay/list/list/ListItem.vue
+++ b/src/components/components/dataDisplay/list/list/ListItem.vue
@@ -47,7 +47,7 @@ export default {
 $list-item-padding-x: 4px;
 
 .c-list-item {
-	padding: 6px $list-item-padding-x;
+	padding: 8px $list-item-padding-x;
 	@include flexbox();
 	@include align-items(center);
 	@include justify-content(space-between);


### PR DESCRIPTION
기존에 medium 사이즈 ListItem 상하 패딩이 6px로 되어있던 것을 8px로 수정

참고: https://comento.agit.io/g/300257914/wall/329454145