### PR TITLE
fix: Chip transparent 우선순위 변경

### DIFF
--- a/src/components/components/dataDisplay/chips/Chip.vue
+++ b/src/components/components/dataDisplay/chips/Chip.vue
@@ -315,7 +315,7 @@ export default {
 		}
 	}
 	&.transparent {
-		background-color: transparent;
+		background-color: transparent !important;
 	}
 	/*사이즈*/
 	&.small {


### PR DESCRIPTION
Chip의 transparent 옵션이 다른 클래스의 background-color에 덮어써져서 important로 최우선 순위로 만들었습니다