### PR TITLE
callout close버튼 위치 조정

### DIFF
--- a/src/components/components/message/Callout.vue
+++ b/src/components/components/message/Callout.vue
@@ -8,7 +8,7 @@
 			v-on="$listeners"
 		>
 			<div class="c-callout--wrapper">
-				<div class="flex align-center">
+				<div class="flex align-center w-full">
 					<!-- 아이콘 -->
 					<slot v-if="$slots['icon']" name="icon" />
 					<Icon v-else :name="iconName" :color="computedIconColor" />
@@ -228,7 +228,7 @@ export default {
 		}
 	}
 	&--close-button {
-		margin-left: 4px;
+		margin-left: auto;
 		flex-shrink: 0;
 	}
 }


### PR DESCRIPTION
callout의 close 버튼이 full일때 오른쪽 끝단으로 가지 않는 이슈가 발생하여 수정 작업을 진행하였습니다