### PR TITLE
Feature/webview optimization

### DIFF
--- a/src/assets/style/base/fonts.scss
+++ b/src/assets/style/base/fonts.scss
@@ -10,6 +10,7 @@ $web-font-family:
   src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Light.woff') format('woff');
   font-weight: 300;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -17,6 +18,7 @@ $web-font-family:
   src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -24,6 +26,7 @@ $web-font-family:
   src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Medium.woff') format('woff');
   font-weight: 500;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
@@ -31,4 +34,5 @@ $web-font-family:
   src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff') format('woff');
   font-weight: 600;
   font-style: normal;
+  font-display: swap;
 }

--- a/src/assets/style/base/fonts.scss
+++ b/src/assets/style/base/fonts.scss
@@ -4,10 +4,13 @@ $web-font-family:
   'Helvetica Neue', Helvetica, Arial,
   'Trebuchet MS',
   sans-serif;
+$root: 'https://cdn.comento.kr/fonts/pretendard/';
 
 @font-face {
   font-family: 'Pretendard';
-  src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Light.woff') format('woff');
+  src: url($root + 'Pretendard-Light.subset.woff2') format('woff2'),
+       url($root + 'Pretendard-Light.subset.woff') format('woff'),
+       url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Light.woff') format('woff');
   font-weight: 300;
   font-style: normal;
   font-display: swap;
@@ -15,7 +18,9 @@ $web-font-family:
 
 @font-face {
   font-family: 'Pretendard';
-  src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
+  src: url($root + 'Pretendard-Regular.subset.woff2') format('woff2'),
+       url($root + 'Pretendard-Regular.subset.woff') format('woff'),
+       url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -23,7 +28,9 @@ $web-font-family:
 
 @font-face {
   font-family: 'Pretendard';
-  src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Medium.woff') format('woff');
+  src: url($root + 'Pretendard-Medium.subset.woff2') format('woff2'),
+       url($root + 'Pretendard-Medium.subset.woff') format('woff'),
+       url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Medium.woff') format('woff');
   font-weight: 500;
   font-style: normal;
   font-display: swap;
@@ -31,7 +38,9 @@ $web-font-family:
 
 @font-face {
   font-family: 'Pretendard';
-  src: url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff') format('woff');
+  src: url($root + 'Pretendard-SemiBold.subset.woff2') format('woff2'),
+       url($root + 'Pretendard-SemiBold.subset.woff') format('woff'),
+       url('https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff') format('woff');
   font-weight: 600;
   font-style: normal;
   font-display: swap;


### PR DESCRIPTION
기존 font asset 크기 : 1.1MB ~ 1.3MB
subset, woff2 형식 크기 : 200KB ~ 300KB

subset, woff2 형식이 기존 cdn에 없어서
코멘토 cdn에 추가하고 반영하였습니다.