### PR TITLE
fix: 사파리 transform 관련 버그 수정

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+	"singleQuote": true,
+	"semi": true,
+	"useTabs": true,
+	"tabWidth": 4,
+	"trailingComma": "all",
+	"printWidth": 120,
+	"bracketSpacing": true,
+	"arrowParens": "avoid",
+	"endOfLine": "auto"
+}

--- a/src/components/components/dataDisplay/card/EduCard.vue
+++ b/src/components/components/dataDisplay/card/EduCard.vue
@@ -156,6 +156,7 @@ export default {
 		animation: scale-down-center 0.2s ease-in both;
 		&-container {
 			position: relative;
+			isolation: isolate;
 			@include border-radius(var(--border-radius));
 			overflow: hidden;
 			width: 100%;

--- a/src/components/components/dataDisplay/card/PromotionEduCard.vue
+++ b/src/components/components/dataDisplay/card/PromotionEduCard.vue
@@ -148,13 +148,14 @@ $backgroundColorAlpha: 0.04;
 		@include opacity(0.9);
 		animation: scale-down-center 0.2s ease-in both;
 		&-container {
+			position: relative;
+			overflow: hidden;
+			@include border-radius(114px);
+			isolation: isolate;
 			margin: -28px 0 -27px;
 			width: 250px;
 			height: 134px;
-			position: relative;
 			border: none;
-			@include border-radius(114px);
-			overflow: hidden;
 		}
 	}
 

--- a/src/components/components/dataDisplay/card/PromotionEduCard.vue
+++ b/src/components/components/dataDisplay/card/PromotionEduCard.vue
@@ -135,8 +135,9 @@ $backgroundColorAlpha: 0.04;
 .c-promotion-edu-card {
 	padding: 0 10px 10px;
 	overflow: hidden;
-	background-color: rgba(var(--dominant-color), $backgroundColorAlpha);
 	@include border-radius(10px);
+	isolation: isolate;
+	background-color: rgba(var(--dominant-color), $backgroundColorAlpha);
 	width: var(--card-width);
 	max-width: 152px;
 	cursor: pointer;


### PR DESCRIPTION
사파리에서 transform을 이용한 애니메이션과 overflow: hidden, border-radius를 같이 썼을 때 버그가 있다고 합니다.

확인해보니 PromotionEduCard, EduCard 두 컴포넌트에서 문제를 보여서 수정했습니다.

[이 블로그](https://www.sungikchoi.com/blog/safari-overflow-border-radius)를 참고했습니다.
