### PR TITLE
change: ql-editor white-space normal로 변경

### DIFF
--- a/src/assets/style/quill/quill.core.css
+++ b/src/assets/style/quill/quill.core.css
@@ -39,7 +39,7 @@
   tab-size: 4;
   -moz-tab-size: 4;
   text-align: left;
-  white-space: pre-wrap;
+  white-space: normal;
   word-wrap: break-word;
 }
 .ql-editor > * {


### PR DESCRIPTION
pre-wrap을 사용하면 실제보다 공백이 더 많이 보이는 이슈.
클래스룸에서 작성한 피드백과 익스턴십에서 작성한 피드백을 과제 디테일에서 봤을 때 다르게 보이는 이슈

https://qa.comenthor.com/classroom/8448
### AS-IS
<img width="529" alt="image" src="https://user-images.githubusercontent.com/32301380/196863625-be764bcc-bac0-4a44-99f7-fb187d99d8b7.png">

### TO-BE
<img width="544" alt="image" src="https://user-images.githubusercontent.com/32301380/196863716-4c5ed024-9ec8-4001-a4b0-e0fcdd7958c1.png">

