### PR TITLE
Feature/change toast top position (#963) (#965)

### DIFF
--- a/src/assets/style/base/variables.scss
+++ b/src/assets/style/base/variables.scss
@@ -40,3 +40,5 @@ $div-user-select:        text;
 
 $alert-height:          56px;
 $alert-height-mobile:   64px;
+
+$topbar-height: 52px;

--- a/src/components/components/message/Toast.vue
+++ b/src/components/components/message/Toast.vue
@@ -168,7 +168,7 @@ export default {
 	}
 
 	&.position-top {
-		top: 32px;
+		top: $topbar-height + 16px;
 		bottom: auto;
 
 		@include pc {


### PR DESCRIPTION
* feat: Toast mobile에서  position top일 때 위치 변경

-
앱 기준 native topbar에 가려지기 때문에 위치 수정
https://www.notion.so/comento/toast-topbar-topbar-f4a05b4c8a04416aa8b604d6dc806cc3

* fix: 문법 수정

-

* refactor: $topbar-height global variable로 이동

-

Co-authored-by: Donghoon Song <32301380+donghoon-song@users.noreply.github.com>