### PR TITLE
fix: 유저프로필에 들어가는 아이콘 사이즈 변경 small -> xsmall

### DIFF
--- a/src/components/components/dataDisplay/content/UserInformationCompany.vue
+++ b/src/components/components/dataDisplay/content/UserInformationCompany.vue
@@ -3,7 +3,7 @@
 		<Typography :type="computedType" color="gray500" class="ellipsis">
 			<slot />
 		</Typography>
-		<Icon name="IconCheckRoundSmallFill" color="primary" class="ml-2" />
+		<Icon name="IconCheckRoundXSmallFill" color="primary" class="ml-2" />
 	</div>
 </template>
 

--- a/stories/components/dataDisplay/content/ProfileWithText.stories.js
+++ b/stories/components/dataDisplay/content/ProfileWithText.stories.js
@@ -39,7 +39,7 @@ storiesOf('Data Display/content/ProfileWithText', module).add('Index', () => ({
 							{{ item.belong }}
 						</template>
 						<template v-slot:icon>
-							<Icon name="IconCheckRoundSmallFill" color="primary"/>
+							<Icon name="IconCheckRoundXSmallFill" color="primary"/>
 						</template>
 						<template v-slot:text>
 							<Typography element="p" type="body2" color="gray800" class="text-truncate">


### PR DESCRIPTION
before
<img width="240" alt="스크린샷 2022-12-27 오전 11 59 13" src="https://user-images.githubusercontent.com/21152295/209604271-86820eed-f70b-45ab-9d48-37ef4087891f.png">


after
<img width="195" alt="스크린샷 2022-12-27 오전 11 59 55" src="https://user-images.githubusercontent.com/21152295/209604292-ed2370df-d4e3-4ac9-abbd-1c3c598ba419.png">
