### PR TITLE
textField label이 노출 되지 않는 현상 수정

### DIFF
--- a/src/components/components/dataEntry/input/TextField.vue
+++ b/src/components/components/dataEntry/input/TextField.vue
@@ -72,7 +72,7 @@ export default {
 		},
 		label: {
 			type: String,
-			default: null,
+			default: '',
 		},
 		outline: {
 			type: Boolean,
@@ -154,7 +154,7 @@ export default {
 			return this.id || `text-field-${this.uid}`;
 		},
 		computedShowLabel() {
-			return this.label;
+			return !!this.label && this.outline && !this.disabled;
 		},
 		computedShowHint() {
 			return !!this.hint && (this.persistentHint || this.isFocused || this.active);
@@ -309,7 +309,7 @@ $disabled-background-color: $gray000;
 	&.label {
 		.c-text-field--input-wrapper {
 			.c-text-field--input {
-				&.outline {
+				&.c-text-field--outline {
 					&:focus,
 					&.active {
 						border-color: $primary;
@@ -325,7 +325,8 @@ $disabled-background-color: $gray000;
 							border-color: $input-border-color;
 						}
 						+ .c-text-field--label {
-							opacity: 0;
+							opacity: 1;
+							color: $gray250;
 						}
 					}
 
@@ -335,17 +336,19 @@ $disabled-background-color: $gray000;
 							color: $error;
 						}
 					}
+
+					+ .c-text-field--label {
+						@include transition(all 0.2s ease);
+						position: absolute;
+						top: -6px;
+						left: 12px;
+						padding: 0 2px;
+						background: $white;
+						color: $gray250;
+						opacity: 1;
+						@include caption2;
+					}
 				}
-			}
-			.c-text-field--label {
-				@include transition(all 0.2s ease);
-				position: absolute;
-				top: -6px;
-				left: 12px;
-				padding: 0 2px;
-				background: $white;
-				@include caption2;
-				opacity: 0;
 			}
 		}
 	}

--- a/stories/components/navigation/SubHeader.stories.mdx
+++ b/stories/components/navigation/SubHeader.stories.mdx
@@ -92,7 +92,6 @@ export const Default = (args, {argTypes}) => ({
            :is-scroll-top="isScrollTop"
            :is-search="isSearch"
            :is-transparent="isTransparent"
-           :is-nuxt="isNuxt"
            :items="items"
            :style="{'--triggered-top': '0 !important'}"
 />


### PR DESCRIPTION
textField의 label이 노출 되지 않는 현상을 수정했습니다.
<img width="1046" alt="스크린샷 2023-08-01 11 43 56" src="https://github.com/comento/comento-ui/assets/75971035/424d7950-0f03-4110-b2d4-1e1dc9c5cfe9">
확인 시점까지 이렇게 노출 되고 있었고

<img width="1046" alt="스크린샷 2023-08-01 11 44 09" src="https://github.com/comento/comento-ui/assets/75971035/571d56e0-ddbd-4ce1-809e-4721de8bcded">
이렇게 변경하였습니다.