### PR TITLE
select disabled시 opacity 적용 위치, font color 변경

### DIFF
--- a/src/components/components/dataEntry/Select.vue
+++ b/src/components/components/dataEntry/Select.vue
@@ -300,13 +300,16 @@ export default {
 <style lang="scss" scoped>
 .c-select {
 	&.disabled {
+		opacity: 0.4;
 		.c-select {
 			&--box,
 			&--item > div,
 			&--item > input,
 			&--icon svg {
-				opacity: 0.4;
 				cursor: not-allowed;
+			}
+			&--input {
+				color: $gray300 !important;
 			}
 		}
 	}


### PR DESCRIPTION
Select 컴포넌트를 disabled 상태로 변경시, 적용 되는 font color와 opacity를 적용하는 부분을 변경하였습니다.
사유는 기획된 디자인과 미세한 색의 차이가 발생했기때문입니다.