### PR TITLE
SearchInput 폰트 사이즈 및 UI 조정

### DIFF
--- a/src/components/components/dataEntry/input/SearchInput.vue
+++ b/src/components/components/dataEntry/input/SearchInput.vue
@@ -34,7 +34,7 @@
 			<Icon
 				role="button"
 				tabindex="1"
-				:name="isMobile ? 'IconSearchSmallLine' : 'IconSearchLargeLine'"
+				name="IconSearchLargeLine"
 				size="medium"
 				:color="computedIconColor"
 				:transparent="transparent"
@@ -184,13 +184,10 @@ export default {
 		@include transition(all 0.2s ease);
 		border: 0;
 		background-color: $gray100;
-		padding: 10px 36px 10px 58px;
-		@include body2();
+		padding: 7.5px 36px 7.5px 58px;
+		@include body1();
 		width: 300px;
 		color: $gray800;
-		@include mobile {
-			padding: 6px 30px 6px 50px;
-		}
 
 		@include placeholder {
 			color: $gray400;


### PR DESCRIPTION
SearchInput 컴포넌트를 클릭시, ios에서 줌인이 발생하는 이슈가 제기 되어, font-size를 줌인을 유발 시키지 않는 16px로 변경하고, 그에 맞게 UI 크기를 조정했습니다.

아지트 업무글 : https://comento.agit.io/g/300257914/wall/345447882