### PR TITLE
fix: Chip xlarge height 수정

### DIFF
--- a/src/components/components/dataDisplay/chips/Chip.vue
+++ b/src/components/components/dataDisplay/chips/Chip.vue
@@ -369,6 +369,7 @@ export default {
 	}
 	&.xlarge {
 		@include body1();
+		height: 34px;
 		padding: 4.5px 12px;
 		font-weight: $regular;
 		@include border-radius(8px);


### PR DESCRIPTION
xlarge size만 height가 들어가 있지 않아서 수정합니다.

### 업무글
https://comento.agit.io/g/300257914/wall/346240366?ir=true&l=agit_io_user_mentioned_v3&sid=346318901&tid=300166075&ts=1718679743#comment_panel_346318901