### PR TITLE
fix: Chip close button 색상 오류 수정, 스토리북 예시 추가

### DIFF
--- a/src/components/chips/Chip.vue
+++ b/src/components/chips/Chip.vue
@@ -137,8 +137,10 @@ export default {
 			return `IconClose${closeButtonIconSize[0] + closeButtonIconSize.slice(1)}Line`;
 		},
 		computedCloseButtonColor() {
-			const whiteColorTypes = ['success', 'secondary', 'error'];
-			if (whiteColorTypes.includes(this.color)) return 'white';
+			const whiteFillColors = ['success', 'secondary'];
+			if (this.type.includes('fill') && whiteFillColors.includes(this.color)) {
+				return 'white';
+			}
 			return this.color;
 		},
 	},

--- a/src/components/chips/Chip.vue
+++ b/src/components/chips/Chip.vue
@@ -137,8 +137,11 @@ export default {
 			return `IconClose${closeButtonIconSize[0] + closeButtonIconSize.slice(1)}Line`;
 		},
 		computedCloseButtonColor() {
-			const whiteFillColors = ['success', 'secondary'];
-			if (this.type.includes('fill') && whiteFillColors.includes(this.color)) {
+			const whiteFillConfig = {
+				colors: ['success', 'secondary'],
+				types: ['fill', 'clickable-fill'],
+			};
+			if (whiteFillConfig.types.includes(this.type) && whiteFillConfig.colors.includes(this.color)) {
 				return 'white';
 			}
 			return this.color;

--- a/stories/components/dataDisplay/Chip.stories.mdx
+++ b/stories/components/dataDisplay/Chip.stories.mdx
@@ -98,10 +98,8 @@ export const Basic = (args, { argTypes }) => ({
                                         <template v-for="(size, index) in ChipSizes">
                                             <Chip :type="type" :color="color" :size="size" class="mr-8">Chip</Chip>
                                         </template>
-                                        <template v-if="type === 'fill'">
-                                          <template v-for="(size, index) in ChipSizesWithCloseButton">
+                                        <template v-for="(size, index) in ChipSizesWithCloseButton">
                                             <Chip :type="type" :color="color" :size="size" with-close-button class="mr-8" @clickCloseButton="handleClickChipClosebutton" @click="handleClick">Chip</Chip>
-                                          </template>
                                         </template>
                                     </div>
                                 </div>


### PR DESCRIPTION
### 1. Chip close button 색상 오류 수정
- as-is
![스크린샷 2024-07-08 오전 11 59 26](https://github.com/comento/comento-ui/assets/19399338/0774197f-b8f9-489b-bf13-6216f6003610)
- to-be
![스크린샷 2024-07-08 오전 11 59 31](https://github.com/comento/comento-ui/assets/19399338/39dbbfc3-6315-42a8-8398-c6a7b6860299)

### 2. Chip 예시 추가
- as-is
![스크린샷 2024-07-08 오후 12 08 35](https://github.com/comento/comento-ui/assets/19399338/078f1e23-adda-43b0-8f56-6e30789fe878)
- to-be
![스크린샷 2024-07-08 오후 12 08 50](https://github.com/comento/comento-ui/assets/19399338/db81d84d-39b8-4da4-8742-0276e98dcd34)

업무글: https://comento.agit.io/g/300257914/wall/346411376