### PR TITLE
feat: Icon에서 cursor 선언 지우기

### DIFF
--- a/src/components/icon/BaseIcon.vue
+++ b/src/components/icon/BaseIcon.vue
@@ -69,7 +69,6 @@ export default {
 
 <style lang="scss" scoped>
 .c-icon {
-	cursor: auto;
 	background: transparent !important;
 	&--link {
 		cursor: pointer;


### PR DESCRIPTION
기존에 Icon에 cursor: auto가 선언되어있는데 아래 이미지와 같은 현상이 나타납니다.
![cursor](https://github.com/user-attachments/assets/dbaad9a1-a0e6-4203-9c8c-40683d3102ea)

cursor는 원래 기본값이 auto인데 이걸 선언하면서 자연스럽게 덮어써질 때도 auto로 다시 돌아가서 그런 것 같아서 삭제했습니다.
![cursor-fixed](https://github.com/user-attachments/assets/a55e2a5a-5f8a-45be-81a0-ae52f08159fd)

혹시 이렇게 선언한 히스토리가 따로 있다면 말씀해주세요.