### PR TITLE
fix: allowTouchMove에서 오류 발생 수정

### DIFF
--- a/src/mixins/scrollMixin.js
+++ b/src/mixins/scrollMixin.js
@@ -7,12 +7,13 @@ const scrollMixin = {
 				reserveScrollBarGap: true,
 				// iOS에서 이슈가 있어서 사용
 				// https://github.com/willmcpo/body-scroll-lock#allowtouchmove
+				// el이 텍스트 노드나 주석 노드 등 일 경우에 dataset 속성이 없을 수 있음
 				allowTouchMove: el => {
 					while (el && el !== document.body) {
 						if (el instanceof HTMLElement && el.dataset && el.dataset.bodyScrollLockIgnore === 'true') {
 							return true;
 						}
-
+						// parentElement를 사용해 항상 텍스트 노드나 주석 노드 등을 건너뜀
 						el = el.parentElement;
 					}
 					return false;

--- a/src/mixins/scrollMixin.js
+++ b/src/mixins/scrollMixin.js
@@ -9,11 +9,11 @@ const scrollMixin = {
 				// https://github.com/willmcpo/body-scroll-lock#allowtouchmove
 				allowTouchMove: el => {
 					while (el && el !== document.body) {
-						if (el.dataset.bodyScrollLockIgnore === 'true') {
+						if (el instanceof HTMLElement && el.dataset && el.dataset.bodyScrollLockIgnore === 'true') {
 							return true;
 						}
 
-						el = el.parentNode;
+						el = el.parentElement;
 					}
 					return false;
 				},


### PR DESCRIPTION
[Datadog](https://app.datadoghq.com/logs?query=service%3Acomento-nuxt%20status%3Aerror%20%22undefined%20is%20not%20an%20object%20evaluating%22&agg_m=count&agg_m_source=base&agg_q=status%2Cservice&agg_q_source=base%2Cbase&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&storage=hot&stream_sort=time%2Cdesc&top_n=10%2C10&top_o=top%2Ctop&viz=stream&x_missing=true%2Ctrue&from_ts=1727056309320&to_ts=1727661109320&live=true)에서 `undefined is not an object (evaluating 't.dataset.bodyScrollLockIgnore')` 오류가 나는 것을 해결하려는 수정입니다.

TextNode 등으로 dataset이 아예 존재하지 않는 el이 있는 것으로 추정되어, HTMLElement인지 확인하고 dataset도 확인합니다