### PR TITLE
서브헤더 사이즈를 디자인에 맞게 수정

### DIFF
--- a/src/components/navigation/subHeader/SubHeader.vue
+++ b/src/components/navigation/subHeader/SubHeader.vue
@@ -55,11 +55,11 @@
 </template>
 
 <script>
+import Button from '@/components/button/Button.vue';
 import NewCol from '@/components/grid/NewCol.vue';
-import Tabs from '@/components/tabs/Tabs.vue';
 import NewGrid from '@/components/grid/NewGrid.vue';
 import NewRow from '@/components/grid/NewRow.vue';
-import Button from '@/components/button/Button.vue';
+import Tabs from '@/components/tabs/Tabs.vue';
 import windowMixin from '@/mixins/windowMixin.js';
 
 /**
@@ -118,7 +118,7 @@ export default {
 $active-bar-transparent: white;
 $hover-background-transparent: rgba(21, 22, 23, 0.1);
 .c-sub-header {
-	width: 100vw;
+	width: 100%;
 	top: 24px;
 	left: 0;
 	background-color: $white;


### PR DESCRIPTION
- 서브헤더의 width 가 100vw로 스크롤 영역까지 포함하고 있어 기존 디자인과 맞지 않는 부분을 수정하였습니다. ( 100vw -> 100% )


**[Before]**
![스크린샷 2025-06-19 16 57 11](https://github.com/user-attachments/assets/f42383f3-b474-463f-b4be-f17b2729bd01)

**[After]**
![스크린샷 2025-06-19 16 58 32](https://github.com/user-attachments/assets/15bdd9f2-7f42-4e21-8247-4b6220dc5dc1)

**[`vw` -> `%` 수정에 따른 레이아웃 변화]**
![Jun-19-2025 17-02-03](https://github.com/user-attachments/assets/380afaf7-43c0-44a3-9396-2ec445fb642f)